### PR TITLE
Dump extra info in github artifacts

### DIFF
--- a/.github/workflows/ab_tests.yml
+++ b/.github/workflows/ab_tests.yml
@@ -114,6 +114,7 @@ jobs:
           path: |
             ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}.db
             cluster_kwargs.*.*
+            mamba_env_export.yml
 
   process-results:
     needs: [discover_ab_envs, tests]

--- a/.github/workflows/ab_tests.yml
+++ b/.github/workflows/ab_tests.yml
@@ -111,7 +111,9 @@ jobs:
         if: always()
         with:
           name: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}
-          path: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}.db
+          path: |
+            ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}.db
+            cluster_kwargs.*.*
 
   process-results:
     needs: [discover_ab_envs, tests]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,9 @@ jobs:
         if: always()
         with:
           name: ${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}
-          path: ${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}.db
+          path: |
+            ${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}.db
+            cluster_kwargs.*.*
 
   process-results:
     needs: tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,6 +117,7 @@ jobs:
           path: |
             ${{ matrix.os }}-${{ matrix.runtime-version }}-py${{ matrix.python-version }}.db
             cluster_kwargs.*.*
+            mamba_env_export.yml
 
   process-results:
     needs: tests

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ dmypy.json
 .pyre/
 
 # Project-specific files
-cluster_kwargs.merged.yaml
+cluster_kwargs.*.pickle
+cluster_kwargs.*.yaml
 benchmark.db
 static/

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ cluster_kwargs.*.pickle
 cluster_kwargs.*.yaml
 benchmark.db
 static/
+mamba_env_export.yml

--- a/ci/scripts/install_coiled_runtime.sh
+++ b/ci/scripts/install_coiled_runtime.sh
@@ -15,4 +15,5 @@ fi
 
 # For debugging
 echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
-mamba env export | grep -E -v '^prefix:.*$'
+mamba env export | grep -E -v '^prefix:.*$' > mamba_env_export.yml
+cat mamba_env_export.yml

--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -26,10 +26,16 @@ small_cluster:
   n_workers: 10
   worker_vm_types: [m6i.large]  # 2CPU, 8GiB
 
-# For test_parquet.py
+# For tests/benchmarks/test_parquet.py
 parquet_cluster:
   n_workers: 15
   worker_vm_types: [m5.xlarge]  # 4 CPU, 16 GiB
+
+# For tests/benchmarks/test_spill.py
+spill_cluster:
+  n_workers: 5
+  worker_disk_size: 64
+  worker_vm_types: [m6i.large]  # 2CPU, 8GiB
 
 # For tests/workflows/test_embarrassingly_parallel.py
 embarrassingly_parallel_cluster:
@@ -44,12 +50,6 @@ embarrassingly_parallel_cluster:
 uber_lyft_cluster:
   n_workers: 20
   worker_vm_types: [m6i.xlarge]  # 4 CPU, 16 GiB
-
-# For test_spill.py
-spill_cluster:
-  n_workers: 5
-  worker_disk_size: 64
-  worker_vm_types: [m6i.large]  # 2CPU, 8GiB
 
 # Specific tests
 test_work_stealing_on_scaling_up:

--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -11,17 +11,21 @@ import pandas
 import pytest
 from coiled import Cluster
 
+from ..conftest import dump_cluster_kwargs
 from ..utils_test import run_up_to_nthreads
 
 
 @pytest.fixture(scope="module")
 def parquet_cluster(dask_env_variables, cluster_kwargs, github_cluster_tags):
-    with Cluster(
-        f"parquet-{uuid.uuid4().hex[:8]}",
+    kwargs = dict(
+        name=f"parquet-{uuid.uuid4().hex[:8]}",
         environ=dask_env_variables,
         tags=github_cluster_tags,
         **cluster_kwargs["parquet_cluster"],
-    ) as cluster:
+    )
+    dump_cluster_kwargs(kwargs, "parquet")
+
+    with Cluster(**kwargs) as cluster:
         yield cluster
 
 

--- a/tests/benchmarks/test_spill.py
+++ b/tests/benchmarks/test_spill.py
@@ -5,6 +5,7 @@ from coiled import Cluster
 from dask.distributed import Client, wait
 from toolz import merge
 
+from ..conftest import dump_cluster_kwargs
 from ..utils_test import (
     cluster_memory,
     print_size_info,
@@ -15,7 +16,7 @@ from ..utils_test import (
 
 @pytest.fixture(scope="module")
 def spill_cluster(dask_env_variables, cluster_kwargs, github_cluster_tags):
-    with Cluster(
+    kwargs = dict(
         name=f"spill-{uuid.uuid4().hex[:8]}",
         environ=merge(
             dask_env_variables,
@@ -27,7 +28,9 @@ def spill_cluster(dask_env_variables, cluster_kwargs, github_cluster_tags):
         ),
         tags=github_cluster_tags,
         **cluster_kwargs["spill_cluster"],
-    ) as cluster:
+    )
+    dump_cluster_kwargs(kwargs, "spill")
+    with Cluster(**kwargs) as cluster:
         yield cluster
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import pathlib
+import pickle
 import shlex
 import subprocess
 import sys
@@ -446,13 +447,18 @@ def load_cluster_kwargs() -> dict:
 
     default = config.pop("default")
     config = {k: dask.config.merge(default, v) for k, v in config.items()}
-
-    # For forensic analysis
-    output_fname = os.path.join(base_dir, "cluster_kwargs.merged.yaml")
-    with open(output_fname, "w") as fh:
-        yaml.dump(config, fh)
-
+    dump_cluster_kwargs(config, "merged")
     return config
+
+
+def dump_cluster_kwargs(kwargs: dict, name: str) -> None:
+    """Dump Cluster **kwargs to disk for forensic analysis"""
+    base_dir = os.path.join(os.path.dirname(__file__), "..")
+    prefix = os.path.join(base_dir, "cluster_kwargs")
+    with open(f"{prefix}.{name}.yaml", "w") as fh:
+        yaml.dump(kwargs, fh)
+    with open(f"{prefix}.{name}.pickle", "wb") as fh:
+        pickle.dump(kwargs, fh)
 
 
 @pytest.fixture(scope="session")
@@ -463,12 +469,15 @@ def cluster_kwargs():
 @pytest.fixture(scope="module")
 def small_cluster(request, dask_env_variables, cluster_kwargs, github_cluster_tags):
     module = os.path.basename(request.fspath).split(".")[0]
-    with Cluster(
+    module = module.replace("test_", "")
+    kwargs = dict(
         name=f"{module}-{uuid.uuid4().hex[:8]}",
         environ=dask_env_variables,
         tags=github_cluster_tags,
         **cluster_kwargs["small_cluster"],
-    ) as cluster:
+    )
+    dump_cluster_kwargs(kwargs, f"small_cluster.{module}")
+    with Cluster(**kwargs) as cluster:
         yield cluster
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -453,10 +453,10 @@ def load_cluster_kwargs() -> dict:
 
 def dump_cluster_kwargs(kwargs: dict, name: str) -> None:
     """Dump Cluster **kwargs to disk for forensic analysis"""
-    assert 'DASK_COILED__TOKEN' in kwargs["environ"]
+    assert "DASK_COILED__TOKEN" in kwargs["environ"]
     kwargs = kwargs.copy()
     kwargs["environ"] = kwargs["environ"].copy()
-    kwargs["environ"]['DASK_COILED__TOKEN'] = "<redacted for dump>"
+    kwargs["environ"]["DASK_COILED__TOKEN"] = "<redacted for dump>"
 
     base_dir = os.path.join(os.path.dirname(__file__), "..")
     prefix = os.path.join(base_dir, "cluster_kwargs")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -453,6 +453,11 @@ def load_cluster_kwargs() -> dict:
 
 def dump_cluster_kwargs(kwargs: dict, name: str) -> None:
     """Dump Cluster **kwargs to disk for forensic analysis"""
+    assert 'DASK_COILED__TOKEN' in kwargs["environ"]
+    kwargs = kwargs.copy()
+    kwargs["environ"] = kwargs["environ"].copy()
+    kwargs["environ"]['DASK_COILED__TOKEN'] = "<redacted for dump>"
+
     base_dir = os.path.join(os.path.dirname(__file__), "..")
     prefix = os.path.join(base_dir, "cluster_kwargs")
     with open(f"{prefix}.{name}.yaml", "w") as fh:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -453,10 +453,10 @@ def load_cluster_kwargs() -> dict:
 
 def dump_cluster_kwargs(kwargs: dict, name: str) -> None:
     """Dump Cluster **kwargs to disk for forensic analysis"""
-    assert "DASK_COILED__TOKEN" in kwargs["environ"]
-    kwargs = kwargs.copy()
-    kwargs["environ"] = kwargs["environ"].copy()
-    kwargs["environ"]["DASK_COILED__TOKEN"] = "<redacted for dump>"
+    if "DASK_COILED__TOKEN" in kwargs.get("environ", {}):
+        kwargs = kwargs.copy()
+        kwargs["environ"] = kwargs["environ"].copy()
+        kwargs["environ"]["DASK_COILED__TOKEN"] = "<redacted for dump>"
 
     base_dir = os.path.join(os.path.dirname(__file__), "..")
     prefix = os.path.join(base_dir, "cluster_kwargs")

--- a/tests/workflows/test_embarrassingly_parallel.py
+++ b/tests/workflows/test_embarrassingly_parallel.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 from dask.distributed import wait
 
-from ..conftest import dump_cluster_kwargs
 
 @pytest.mark.client("embarrassingly_parallel")
 def test_embarassingly_parallel(client, s3_factory):

--- a/tests/workflows/test_embarrassingly_parallel.py
+++ b/tests/workflows/test_embarrassingly_parallel.py
@@ -7,6 +7,8 @@ import pandas as pd
 import pytest
 from dask.distributed import Client, wait
 
+from ..conftest import dump_cluster_kwargs
+
 
 @pytest.fixture(scope="module")
 def embarrassingly_parallel_cluster(
@@ -14,12 +16,14 @@ def embarrassingly_parallel_cluster(
     cluster_kwargs,
     github_cluster_tags,
 ):
-    with coiled.Cluster(
-        f"embarrassingly-parallel-{uuid.uuid4().hex[:8]}",
+    kwargs = dict(
+        name=f"embarrassingly_parallel-{uuid.uuid4().hex[:8]}",
         environ=dask_env_variables,
         tags=github_cluster_tags,
         **cluster_kwargs["embarrassingly_parallel_cluster"],
-    ) as cluster:
+    )
+    dump_cluster_kwargs(kwargs, "embarassingly_parallel")
+    with coiled.Cluster(**kwargs) as cluster:
         yield cluster
 
 

--- a/tests/workflows/test_uber_lyft.py
+++ b/tests/workflows/test_uber_lyft.py
@@ -5,6 +5,8 @@ import dask.dataframe as dd
 import pytest
 from dask.distributed import Client
 
+from ..conftest import dump_cluster_kwargs
+
 
 @pytest.fixture(scope="module")
 def uber_lyft_cluster(
@@ -12,12 +14,14 @@ def uber_lyft_cluster(
     cluster_kwargs,
     github_cluster_tags,
 ):
-    with coiled.Cluster(
-        f"uber-lyft-{uuid.uuid4().hex[:8]}",
+    kwargs = dict(
+        name=f"uber_lyft-{uuid.uuid4().hex[:8]}",
         environ=dask_env_variables,
         tags=github_cluster_tags,
         **cluster_kwargs["uber_lyft_cluster"],
-    ) as cluster:
+    )
+    dump_cluster_kwargs(kwargs, "uber_lyft")
+    with coiled.Cluster() as cluster:
         yield cluster
 
 

--- a/tests/workflows/test_uber_lyft.py
+++ b/tests/workflows/test_uber_lyft.py
@@ -1,7 +1,6 @@
 import dask.dataframe as dd
 import pytest
 
-from ..conftest import dump_cluster_kwargs
 
 @pytest.mark.client("uber_lyft")
 def test_exploratory_analysis(client):


### PR DESCRIPTION
Dump all kwargs passed to `coiled.Cluster`, as well as the output of `mamba env export`, to the github artifacts. This can be useful to debug issues.

XREF #756