### PR TITLE
Remove redundant `python-version` from CI

### DIFF
--- a/.github/workflows/ab_tests.yml
+++ b/.github/workflows/ab_tests.yml
@@ -62,14 +62,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniforge-variant: Mambaforge
-          use-mamba: true
-          condarc-file: ci/condarc
-          environment-file: ci/environment.yml
-
       - name: Create null hypothesis as a copy of baseline
         if: matrix.runtime-version == 'AB_null_hypothesis'
         run: |
@@ -78,11 +70,17 @@ jobs:
           cp AB_baseline.dask.yaml AB_null_hypothesis.dask.yaml
           cp AB_baseline.cluster.yaml AB_null_hypothesis.cluster.yaml
 
-      - name: Install coiled-runtime
-        env:
-          COILED_RUNTIME_VERSION: ${{ matrix.runtime-version }}
+      - name: Set up environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          use-mamba: true
+          condarc-file: ci/condarc
+          environment-file: AB_environments/${{ matrix.runtime-version }}.conda.yaml
+
+      - name: mamba env export
         run: |
-          source ci/scripts/install_coiled_runtime.sh AB_environments/${{ matrix.runtime-version }}.conda.yaml
+          mamba env export | grep -E -v '^prefix:.*$'
 
       - name: Convert dask config into environment variables
         run: python ci/scripts/dask_config_to_env.py AB_environments/${{ matrix.runtime-version }}.dask.yaml >> $GITHUB_ENV

--- a/.github/workflows/ab_tests.yml
+++ b/.github/workflows/ab_tests.yml
@@ -43,7 +43,7 @@ jobs:
   # and AB_environments/config.yaml set repeat > 0
 
   tests:
-    name: A/B Tests - ${{ matrix.runtime-version }} ${{ matrix.os }} py${{ matrix.python-version }}
+    name: A/B Tests - ${{ matrix.runtime-version }} ${{ matrix.os }}
     needs: discover_ab_envs
     if: fromJson(needs.discover_ab_envs.outputs.matrix).run_AB
     runs-on: ${{ matrix.os }}
@@ -53,7 +53,6 @@ jobs:
       max-parallel: ${{ fromJson(needs.discover_ab_envs.outputs.matrix).max_parallel }}
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9"]
         pytest_args: ${{ fromJson(needs.discover_ab_envs.outputs.matrix).pytest_args }}
         runtime-version: ${{ fromJson(needs.discover_ab_envs.outputs.matrix).runtime }}
         repeat: ${{ fromJson(needs.discover_ab_envs.outputs.matrix).repeat }}
@@ -69,7 +68,6 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           condarc-file: ci/condarc
-          python-version: ${{ matrix.python-version }}
           environment-file: ci/environment.yml
 
       - name: Create null hypothesis as a copy of baseline
@@ -96,7 +94,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.RUNTIME_CI_BOT_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RUNTIME_CI_BOT_AWS_SECRET_ACCESS_KEY }}
           COILED_RUNTIME_VERSION: ${{ matrix.runtime-version }}
-          DB_NAME: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}.db
+          DB_NAME: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}.db
           BENCHMARK: true
           CLUSTER_DUMP: always
           CLUSTER_KWARGS: AB_environments/${{ matrix.runtime-version }}.cluster.yaml
@@ -110,8 +108,8 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}
-          path: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}-py${{ matrix.python-version }}.db
+          name: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}
+          path: ${{ matrix.os }}-${{ matrix.runtime-version }}-${{ matrix.repeat }}.db
 
   process-results:
     needs: [discover_ab_envs, tests]
@@ -171,7 +169,6 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
-          python-version: "3.9"
           environment-file: ci/environment-dashboard.yml
 
       - name: Generate dashboards

--- a/.github/workflows/ab_tests.yml
+++ b/.github/workflows/ab_tests.yml
@@ -78,6 +78,9 @@ jobs:
           condarc-file: ci/condarc
           environment-file: AB_environments/${{ matrix.runtime-version }}.conda.yaml
 
+      - name: Add extra packages to environment
+        run: mamba env update -f ci/environment.yml
+
       - name: mamba env export
         run: |
           mamba env export | grep -E -v '^prefix:.*$'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -193,7 +193,6 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
-          python-version: "3.9"
           environment-file: ci/environment-dashboard.yml
 
       - name: Run detect regressions
@@ -260,7 +259,6 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
-          python-version: "3.9"
           environment-file: ci/environment-dashboard.yml
 
       - name: Generate dashboards

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -5,11 +5,9 @@ dependencies:
   - packaging
   - pytest
   - pytest-xdist
-  - python
   - pyyaml
   - sqlalchemy
   - alembic
   # Temporary workaround for `filelock=3.11.0` causing package sync to deadlock
   - filelock=3.10.7
   - cftime
-  - conda

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   # Temporary workaround for `filelock=3.11.0` causing package sync to deadlock
   - filelock=3.10.7
   - cftime
+  - conda


### PR DESCRIPTION
Remove python-version from CI scripts when it's already pinned in the conda recipe. This change is purely cosmetic; `conda-incubator/setup-miniconda@v2` does the right thing and ignores it.