### PR TITLE
Add context when using default worker instance type

### DIFF
--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -34,16 +34,12 @@ parquet_cluster:
 # For tests/workflows/test_embarrassingly_parallel.py
 embarrassingly_parallel_cluster:
   n_workers: 100
-  # TODO: Remove the `m6i.xlarge` worker specification below
-  # once it's the default worker instance type
-  worker_vm_types: [m6i.xlarge]  # 4 CPU, 16 GiB
   backend_options:
     region: "us-east-1"  # Same region as dataset
 
 # For tests/workflows/test_uber_lyft.py
 uber_lyft_cluster:
   n_workers: 20
-  worker_vm_types: [m6i.xlarge]  # 4 CPU, 16 GiB
 
 # For test_spill.py
 spill_cluster:

--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -34,12 +34,14 @@ parquet_cluster:
 # For tests/workflows/test_embarrassingly_parallel.py
 embarrassingly_parallel_cluster:
   n_workers: 100
+  worker_vm_types: [m6i.xlarge] # 4 CPU, 16 GiB (preferred default instance)
   backend_options:
     region: "us-east-1"  # Same region as dataset
 
 # For tests/workflows/test_uber_lyft.py
 uber_lyft_cluster:
   n_workers: 20
+  worker_vm_types: [m6i.xlarge] # 4 CPU, 16 GiB (preferred default instance)
 
 # For test_spill.py
 spill_cluster:


### PR DESCRIPTION
`m6i.xlarge` is now our default instance type, so we should need to specify these `worker_vm_types` anymore 

cc @ntabris 