### PR TITLE
Add pytest marker/fixture for client creation

### DIFF
--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -32,19 +32,19 @@ parquet_cluster:
   worker_vm_types: [m5.xlarge]  # 4 CPU, 16 GiB
 
 # For tests/workflows/test_embarrassingly_parallel.py
-embarrassingly_parallel_cluster:
+embarrassingly_parallel:
   n_workers: 100
   worker_vm_types: [m6i.xlarge] # 4 CPU, 16 GiB (preferred default instance)
   backend_options:
     region: "us-east-1"  # Same region as dataset
 
-# For tests/workflows/test_optuna.py
-optuna_cluster:
+# For tests/workflows/test_xgboost_optuna.py
+xgboost_optuna:
   n_workers: 50
   worker_vm_types: [m6i.xlarge]  # 4 CPU, 16 GiB (preferred default instance)
 
 # For tests/workflows/test_uber_lyft.py
-uber_lyft_cluster:
+uber_lyft:
   n_workers: 20
   worker_vm_types: [m6i.xlarge] # 4 CPU, 16 GiB (preferred default instance)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -517,6 +517,34 @@ def small_client(
         client.run(lambda: None)
 
 
+@pytest.fixture
+def client(
+    request,
+    dask_env_variables,
+    cluster_kwargs,
+    github_cluster_tags,
+    upload_cluster_dump,
+    benchmark_all,
+):
+    name = request.param
+    with Cluster(
+        f"{name}-{uuid.uuid4().hex[:8]}",
+        environ=dask_env_variables,
+        tags=github_cluster_tags,
+        **cluster_kwargs[name],
+    ) as cluster:
+        with Client(cluster) as client:
+            with upload_cluster_dump(client), benchmark_all(client):
+                yield client
+
+
+def _mark_client(name):
+    return pytest.mark.parametrize("client", [name], indirect=True)
+
+
+pytest.mark.client = _mark_client
+
+
 S3_REGION = "us-east-2"
 S3_BUCKET = "s3://coiled-runtime-ci"
 

--- a/tests/workflows/test_embarrassingly_parallel.py
+++ b/tests/workflows/test_embarrassingly_parallel.py
@@ -1,45 +1,13 @@
 import io
 import tarfile
-import uuid
 
-import coiled
 import pandas as pd
 import pytest
-from dask.distributed import Client, wait
+from dask.distributed import wait
 
 
-@pytest.fixture(scope="module")
-def embarrassingly_parallel_cluster(
-    dask_env_variables,
-    cluster_kwargs,
-    github_cluster_tags,
-):
-    with coiled.Cluster(
-        f"embarrassingly-parallel-{uuid.uuid4().hex[:8]}",
-        environ=dask_env_variables,
-        tags=github_cluster_tags,
-        **cluster_kwargs["embarrassingly_parallel_cluster"],
-    ) as cluster:
-        yield cluster
-
-
-@pytest.fixture
-def embarrassingly_parallel_client(
-    embarrassingly_parallel_cluster,
-    cluster_kwargs,
-    upload_cluster_dump,
-    benchmark_all,
-):
-    n_workers = cluster_kwargs["embarrassingly_parallel_cluster"]["n_workers"]
-    with Client(embarrassingly_parallel_cluster) as client:
-        embarrassingly_parallel_cluster.scale(n_workers)
-        client.wait_for_workers(n_workers)
-        client.restart()
-        with upload_cluster_dump(client), benchmark_all(client):
-            yield client
-
-
-def test_embarassingly_parallel(embarrassingly_parallel_client, s3_factory):
+@pytest.mark.client("embarrassingly_parallel")
+def test_embarassingly_parallel(client, s3_factory):
     # How popular is matplotlib?
     s3 = s3_factory(requester_pays=True)
     directories = s3.ls("s3://arxiv/pdf")
@@ -74,11 +42,11 @@ def test_embarassingly_parallel(embarrassingly_parallel_client, s3_factory):
                             out.append((member.name, b"matplotlib" in data.lower()))
                 return out
 
-    futures = embarrassingly_parallel_client.map(extract, directories, fs=s3)
+    futures = client.map(extract, directories, fs=s3)
     wait(futures)
     # We had one error in one file.  Let's just ignore and move on.
     good = [future for future in futures if future.status == "finished"]
-    data = embarrassingly_parallel_client.gather(good)
+    data = client.gather(good)
 
     # Convert to Pandas
     dfs = [pd.DataFrame(d, columns=["filename", "has_matplotlib"]) for d in data]

--- a/tests/workflows/test_uber_lyft.py
+++ b/tests/workflows/test_uber_lyft.py
@@ -1,43 +1,9 @@
-import uuid
-
-import coiled
 import dask.dataframe as dd
 import pytest
-from dask.distributed import Client
 
 
-@pytest.fixture(scope="module")
-def uber_lyft_cluster(
-    dask_env_variables,
-    cluster_kwargs,
-    github_cluster_tags,
-):
-    with coiled.Cluster(
-        f"uber-lyft-{uuid.uuid4().hex[:8]}",
-        environ=dask_env_variables,
-        tags=github_cluster_tags,
-        **cluster_kwargs["uber_lyft_cluster"],
-    ) as cluster:
-        yield cluster
-
-
-@pytest.fixture
-def uber_lyft_client(
-    uber_lyft_cluster,
-    cluster_kwargs,
-    upload_cluster_dump,
-    benchmark_all,
-):
-    n_workers = cluster_kwargs["uber_lyft_cluster"]["n_workers"]
-    with Client(uber_lyft_cluster) as client:
-        uber_lyft_cluster.scale(n_workers)
-        client.wait_for_workers(n_workers)
-        client.restart()
-        with upload_cluster_dump(client), benchmark_all(client):
-            yield client
-
-
-def test_exploratory_analysis(uber_lyft_client):
+@pytest.mark.client("uber_lyft")
+def test_exploratory_analysis(client):
     """Run some exploratory aggs on the dataset"""
 
     # NYC taxi Uber/Lyft dataset


### PR DESCRIPTION
Currently there's quite a bit of boilerplate code that's getting copy-pasted in each workflow module. This PR moves that code into a pytest marker + fixture for reuse / a more pleasant interface. 

Steps here are to:

1. Add named cluster spec to `cluster_kwargs.yaml`
2. Mark test with `@pytest.mark.client(<spec-name>)`
3. Add the `client` fixture to the test (the materialized `client` will be attached to a cluster with the given spec)

This seems like a decent improvement to me 