### PR TITLE
Upgrade to zict 3.0

### DIFF
--- a/AB_environments/AB_baseline.conda.yaml
+++ b/AB_environments/AB_baseline.conda.yaml
@@ -31,7 +31,7 @@ dependencies:
     - cloudpickle ==2.2.1
     - tornado ==6.2
     - toolz ==0.12.0
-    - zict ==2.2.0
+    - zict ==3.0.0
     - xgboost ==1.7.4
     - dask-ml ==2023.3.24
     - openssl >1.1.0g

--- a/AB_environments/AB_sample.conda.yaml
+++ b/AB_environments/AB_sample.conda.yaml
@@ -36,7 +36,7 @@ dependencies:
     - cloudpickle ==2.2.1
     - tornado ==6.2
     - toolz ==0.12.0
-    - zict ==2.2.0
+    - zict ==3.0.0
     - xgboost ==1.7.4
     - dask-ml ==2023.3.24
     - openssl >1.1.0g

--- a/AB_environments/README.md
+++ b/AB_environments/README.md
@@ -158,7 +158,7 @@ dependencies:
     - cloudpickle ==2.2.1
     - tornado ==6.2
     - toolz ==0.12.0
-    - zict ==2.2.0
+    - zict ==3.0.0
     - xgboost ==1.7.4
     - dask-ml ==2023.3.24
     - openssl >1.1.0g

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - cloudpickle ==2.2.1
     - tornado ==6.2
     - toolz ==0.12.0
-    - zict ==2.2.0
+    - zict ==3.0.0
     - xgboost ==1.7.4
     - dask-ml ==2023.3.24
     - openssl >1.1.0g


### PR DESCRIPTION
Avoids unnecessary deep-copy when unspilling uncompressed numpy arrays (dask/zict#74)