### PR TITLE
Parse zarr and xgboost tests

### DIFF
--- a/ci/environment-dashboard.yml
+++ b/ci/environment-dashboard.yml
@@ -7,14 +7,19 @@ dependencies:
   - altair=4.2
   - bokeh
   - panel=0.13
+  - pandas=1.4  # 1.5 is incompatibile with altair 4.2
+  - tabulate
+
+  # These imports are only needed to parse the source code of the tests and embed it in
+  # the dashboard
   - coiled
+  - conda
   - dask
   - dask-ml
   - distributed
+  - filelock
+  - optuna
+  - s3fs
   - xarray
   - xgboost
-  - pandas=1.4  # 1.5 is incompatibile with altair 4.2
-  - tabulate
-  - conda
-  - filelock
-  - s3fs
+  - zarr


### PR DESCRIPTION
Fixes
```
python dashboard.py -d benchmark.db -o static -b coiled-AB_baseline-py$PY_VER
Could not import tests/benchmarks/test_zarr.py: Skipped: could not import 'zarr': No module named 'zarr'
Could not import tests/workflows/test_xgboost_optuna.py: Skipped: could not import 'optuna': No module named 'optuna'
```