### PR TITLE
Disable test_join_big_small[0.1]

### DIFF
--- a/tests/benchmarks/test_join.py
+++ b/tests/benchmarks/test_join.py
@@ -33,6 +33,9 @@ def test_join_big(small_client, memory_multiplier, configure_shuffling):
 
 
 def test_join_big_small(small_client, memory_multiplier, configure_shuffling):
+    if memory_multiplier == 0.1:
+        raise pytest.skip(reason="Too noisy; not adding anything to multiplier=1")
+
     memory = cluster_memory(small_client)  # 76.66 GiB
 
     df_big = timeseries_of_size(


### PR DESCRIPTION
This test is very noisy and really doesn't add anything to test_join_big_small[1].
Note also how test_join_big_small[1] doesn't spill - which would be one thing that would make it different.

A/B test on 7 runs vs. null hypothesis:
![image](https://user-images.githubusercontent.com/6213168/234842711-e9dec7d4-c8ac-4cee-8dda-081f95856ef1.png)


![Screenshot from 2023-04-27 11-48-54](https://user-images.githubusercontent.com/6213168/234842219-af0025a1-9833-4150-983b-98c0090ab183.png)


Note how the end-to-end runtime is heavily cluster-driven: the four tests run one after another on the same cluster and you can see that, given the same cluster, they have exactly the same end-to-end runtime minus a fixed offset.

![Screenshot from 2023-04-27 11-51-03](https://user-images.githubusercontent.com/6213168/234842228-1d90a5f7-8d9e-4dfa-aad2-7b12853042e3.png)

