### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,14 @@
-# Coiled Runtime
+# Coiled Benchmarks
 
 [![Tests](https://github.com/coiled/benchmarks/actions/workflows/tests.yml/badge.svg)](https://github.com/coiled/benchmarks/actions/workflows/tests.yml)
 [![Linting](https://github.com/coiled/benchmarks/actions/workflows/lint.yml/badge.svg)](https://github.com/coiled/benchmarks/actions/workflows/lint.yml)
 [![Benchmarks](https://shields.io/badge/-Benchmarks-blue)](https://benchmarks.coiled.io)
 
-The Coiled Runtime is a conda metapackage which makes it easy to get started with Dask.
+Set of Dask benchmarks run daily at scale in Coiled Clusters.
 
-## Install
+## Test Locally (for developers)
 
-`coiled-runtime` can be installed with `conda`:
-
-```bash
-conda install -c conda-forge coiled-runtime
-```
-
-or with `pip`:
-
-```bash
-pip install coiled-runtime
-```
-
-
-**Nightly builds**
-  
-`coiled-runtime` has nightly conda packages for testing purposes.
-You can install a nightly version of `coiled-runtime` with:
-
-```bash
-conda install -c coiled/label/dev -c dask/label/dev coiled-runtime 
-```
-
-## Build
-
-To build and install `coiled-runtime` locally, use the following steps:
-
-```bash
-# Have a local copy of the `coiled-runtime` repository
-git clone https://github.com/coiled/benchmarks
-cd coiled-runtime
-
-# Make sure conda-build is installed
-conda install -c conda-forge conda-build
-
-# Build the metapackage
-conda build recipe -c conda-forge --output-folder dist/conda --no-anaconda-upload
-
-# Install the built `coiled-runtime` metapackage
-conda install -c ./dist/conda/ -c conda-forge coiled-runtime
-```
-
-## Test
-
-The `coiled-runtime` test suite can be run locally with the following steps:
+The `coiled benchmarks` test suite can be run locally with the following steps:
 
 1. Ensure your local machine is authenticated to use the `dask-engineering` Coiled account and
    the Coiled Dask Engineering AWS S3 account.
@@ -69,7 +26,7 @@ See the section below on creating pull requests.
 
 ## Benchmarking
 
-The `coiled-runtime` test suite contains a series of pytest fixtures which enable
+The `coiled-benchmarks` test suite contains a series of pytest fixtures which enable
 benchmarking metrics to be collected and stored for historical and regression analysis.
 By default, these metrics are not collected and stored, but they can be enabled
 by including the `--benchmark` flag in your pytest invocation.
@@ -242,39 +199,6 @@ grant access to secrets for forked repositories](https://docs.github.com/en/acti
 **please submit pull requests directly from the `coiled/benchmarks` repository,
 not a personal fork**.
 
-## Release
-
-To issue a new `coiled-runtime` release:
-
-1. Locally update the `coiled-runtime` version and package pinnings specified in `recipe/meta.yaml`.
-    - When updating package version pinnings (in particular `dask` and `distributed`)
-      confirm there are no reported large scale stability issues (e.g. deadlocks) or
-      performance regressions on the `dask` / `distributed` issue trackers or offline
-      reports.
-2. Open a pull request to the `coiled-runtime` repository titled "Release X.Y.Z" with these changes
-   (where `X.Y.Z` is replaced with the actual version for the release).
-3. After all CI builds have passed the release pull request can be merged.
-4. Add a new git tag for the release by following the steps below on your local machine:
-
-```bash
-# Pull in changes from the Release X.Y.Z PR
-git checkout main
-git pull origin main
-
-# Set release version number
-export RELEASE=X.Y.Z
-# Create and push release tag
-git tag -a $RELEASE -m "Version $RELEASE"
-git push origin main --tags
-```
-
-5. Update the `coiled-runtime` package on conda-forge by opening a pull request to the
-   [`coiled-runtime` conda-forge feedstock](https://github.com/conda-forge/coiled-runtime-feedstock)
-   which updates the `coiled-runtime` version and package version pinnings.
-    - Note that pull requests to conda-forge feedstocks must come from a fork.
-    - Reset the build number back to `0` if it isn't already.
-    - For more information on updating conda-forge packages, see the
-      [conda-forge docs](https://conda-forge.org/docs/maintainer/updating_pkgs.html).
 
 ## License
 


### PR DESCRIPTION
- Closes #835
This is a quick update that removes the mentions of coiled runtime, especially since @crusaderky blog is out, we want to avoid confusion. 



