### PR TITLE
[DNM] Try using placement group (faster worker <-> worker network)

### DIFF
--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -20,6 +20,7 @@ default:
     spot: true
     spot_on_demand_fallback: true
     multizone: true
+    use_placement_group: true
 
 # For all tests using the small_client fixture
 small_cluster:


### PR DESCRIPTION
I'm especially curious if this makes an impact on something like the vorticity test now that (in upstream dask) comms aren't slowed down by compression.