### PR TITLE
Squash github pages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -279,8 +279,9 @@ jobs:
           path: static
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.7
+        uses: JamesIves/github-pages-deploy-action@4.4.1
         if:  github.ref == 'refs/heads/main' && github.repository == 'coiled/benchmarks'
         with:
           branch: gh-pages
           folder: static
+          single-commit: true


### PR DESCRIPTION
For quite a while I've been manually squashing the history of github pages.
This drastically reduces the time needed to run `git fetch` as well as the size of the `.git` folder on disk.
This PR automates the process.