### PR TITLE
Pin GPU VM type for Pytorch + Optuna GPU workload

### DIFF
--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -56,7 +56,7 @@ uber_lyft:
 # For tests/workflows/test_pytorch_optuna.py
 pytorch_optuna:
   n_workers: 10
-  worker_gpu: 1
+  worker_vm_types: [g4dn.xlarge] # 1 GPU, 4 CPU, 16 GiB
   worker_options:
     # Making workers single-threaded to avoid GPU contention. See discussion in
     # https://github.com/coiled/benchmarks/pull/787#discussion_r1177004248 for


### PR DESCRIPTION
Follow-up to #787 pinning the VM type as AWS would otherwise vary this between runs. See https://coiledcomputing.slack.com/archives/C018NCJG8LX/p1685449020103739 (Coiled only)