### PR TITLE
Imbalanced join workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,28 +33,28 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.9"]
         pytest_args: [tests]
-        include:
-          # Run stability tests on the lowest and highest versions of Python only
-          # These are temporarily redundant with the current global python-version
-          # - pytest_args: tests/stability
-          #   python-version: "3.9"
-          #   os: ubuntu-latest
-          # - pytest_args: tests/stability
-          #   python-version: "3.9"
-          #   os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.11"
-            os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.11"
-            os: ubuntu-latest
-          # Run stability tests on Python Windows and MacOS (latest py39 only)
-          - pytest_args: tests/stability
-            python-version: "3.9"
-            os: windows-latest
-          - pytest_args: tests/stability
-            python-version: "3.9"
-            os: macos-latest
+#        include:
+#          # Run stability tests on the lowest and highest versions of Python only
+#          # These are temporarily redundant with the current global python-version
+#          # - pytest_args: tests/stability
+#          #   python-version: "3.9"
+#          #   os: ubuntu-latest
+#          # - pytest_args: tests/stability
+#          #   python-version: "3.9"
+#          #   os: ubuntu-latest
+#          - pytest_args: tests/stability
+#            python-version: "3.11"
+#            os: ubuntu-latest
+#          - pytest_args: tests/stability
+#            python-version: "3.11"
+#            os: ubuntu-latest
+#          # Run stability tests on Python Windows and MacOS (latest py39 only)
+#          - pytest_args: tests/stability
+#            python-version: "3.9"
+#            os: windows-latest
+#          - pytest_args: tests/stability
+#            python-version: "3.9"
+#            os: macos-latest
 
     steps:
       - name: Checkout
@@ -108,7 +108,8 @@ jobs:
           DB_NAME: ${{ matrix.os }}-py${{ matrix.python-version }}.db
           BENCHMARK: true
           CLUSTER_DUMP: always
-        run: bash ci/scripts/run_tests.sh -n 4 --dist loadscope ${{ env.EXTRA_OPTIONS }} ${{ matrix.pytest_args }}
+        # run: bash ci/scripts/run_tests.sh -n 4 --dist loadscope ${{ env.EXTRA_OPTIONS }} ${{ matrix.pytest_args }}
+        run: python -m pytest --run-workflows tests/workflows/test_imbalanced_join.py
 
       - name: Dump coiled.Cluster kwargs
         run: cat cluster_kwargs.merged.yaml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,28 +33,28 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.9"]
         pytest_args: [tests]
-#        include:
-#          # Run stability tests on the lowest and highest versions of Python only
-#          # These are temporarily redundant with the current global python-version
-#          # - pytest_args: tests/stability
-#          #   python-version: "3.9"
-#          #   os: ubuntu-latest
-#          # - pytest_args: tests/stability
-#          #   python-version: "3.9"
-#          #   os: ubuntu-latest
-#          - pytest_args: tests/stability
-#            python-version: "3.11"
-#            os: ubuntu-latest
-#          - pytest_args: tests/stability
-#            python-version: "3.11"
-#            os: ubuntu-latest
-#          # Run stability tests on Python Windows and MacOS (latest py39 only)
-#          - pytest_args: tests/stability
-#            python-version: "3.9"
-#            os: windows-latest
-#          - pytest_args: tests/stability
-#            python-version: "3.9"
-#            os: macos-latest
+        include:
+          # Run stability tests on the lowest and highest versions of Python only
+          # These are temporarily redundant with the current global python-version
+          # - pytest_args: tests/stability
+          #   python-version: "3.9"
+          #   os: ubuntu-latest
+          # - pytest_args: tests/stability
+          #   python-version: "3.9"
+          #   os: ubuntu-latest
+          - pytest_args: tests/stability
+            python-version: "3.11"
+            os: ubuntu-latest
+          - pytest_args: tests/stability
+            python-version: "3.11"
+            os: ubuntu-latest
+          # Run stability tests on Python Windows and MacOS (latest py39 only)
+          - pytest_args: tests/stability
+            python-version: "3.9"
+            os: windows-latest
+          - pytest_args: tests/stability
+            python-version: "3.9"
+            os: macos-latest
 
     steps:
       - name: Checkout
@@ -108,8 +108,7 @@ jobs:
           DB_NAME: ${{ matrix.os }}-py${{ matrix.python-version }}.db
           BENCHMARK: true
           CLUSTER_DUMP: always
-        # run: bash ci/scripts/run_tests.sh -n 4 --dist loadscope ${{ env.EXTRA_OPTIONS }} ${{ matrix.pytest_args }}
-        run: python -m pytest --run-workflows tests/workflows/test_imbalanced_join.py
+        run: bash ci/scripts/run_tests.sh -n 4 --dist loadscope ${{ env.EXTRA_OPTIONS }} ${{ matrix.pytest_args }}
 
       - name: Dump coiled.Cluster kwargs
         run: cat cluster_kwargs.merged.yaml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.9"]
         pytest_args: [tests]
-#        include:
+        include:
           # Run stability tests on the lowest and highest versions of Python only
           # These are temporarily redundant with the current global python-version
           # - pytest_args: tests/stability
@@ -42,19 +42,19 @@ jobs:
           # - pytest_args: tests/stability
           #   python-version: "3.9"
           #   os: ubuntu-latest
-#          - pytest_args: tests/stability
-#            python-version: "3.11"
-#            os: ubuntu-latest
-#          - pytest_args: tests/stability
-#            python-version: "3.11"
-#            os: ubuntu-latest
+          - pytest_args: tests/stability
+            python-version: "3.11"
+            os: ubuntu-latest
+          - pytest_args: tests/stability
+            python-version: "3.11"
+            os: ubuntu-latest
           # Run stability tests on Python Windows and MacOS (latest py39 only)
-#          - pytest_args: tests/stability
-#            python-version: "3.9"
-#            os: windows-latest
-#          - pytest_args: tests/stability
-#            python-version: "3.9"
-#            os: macos-latest
+          - pytest_args: tests/stability
+            python-version: "3.9"
+            os: windows-latest
+          - pytest_args: tests/stability
+            python-version: "3.9"
+            os: macos-latest
 
     steps:
       - name: Checkout
@@ -108,8 +108,7 @@ jobs:
           DB_NAME: ${{ matrix.os }}-py${{ matrix.python-version }}.db
           BENCHMARK: true
           CLUSTER_DUMP: always
-        # run: bash ci/scripts/run_tests.sh -n 4 --dist loadscope ${{ env.EXTRA_OPTIONS }} ${{ matrix.pytest_args }}
-        run: python -m pytest --run-workflows tests/workflows/test_imbalanced_join.py
+        run: bash ci/scripts/run_tests.sh -n 4 --dist loadscope ${{ env.EXTRA_OPTIONS }} ${{ matrix.pytest_args }}
 
       - name: Dump coiled.Cluster kwargs
         run: cat cluster_kwargs.merged.yaml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.9"]
         pytest_args: [tests]
-        include:
+#        include:
           # Run stability tests on the lowest and highest versions of Python only
           # These are temporarily redundant with the current global python-version
           # - pytest_args: tests/stability
@@ -42,19 +42,19 @@ jobs:
           # - pytest_args: tests/stability
           #   python-version: "3.9"
           #   os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.11"
-            os: ubuntu-latest
-          - pytest_args: tests/stability
-            python-version: "3.11"
-            os: ubuntu-latest
+#          - pytest_args: tests/stability
+#            python-version: "3.11"
+#            os: ubuntu-latest
+#          - pytest_args: tests/stability
+#            python-version: "3.11"
+#            os: ubuntu-latest
           # Run stability tests on Python Windows and MacOS (latest py39 only)
-          - pytest_args: tests/stability
-            python-version: "3.9"
-            os: windows-latest
-          - pytest_args: tests/stability
-            python-version: "3.9"
-            os: macos-latest
+#          - pytest_args: tests/stability
+#            python-version: "3.9"
+#            os: windows-latest
+#          - pytest_args: tests/stability
+#            python-version: "3.9"
+#            os: macos-latest
 
     steps:
       - name: Checkout
@@ -108,7 +108,8 @@ jobs:
           DB_NAME: ${{ matrix.os }}-py${{ matrix.python-version }}.db
           BENCHMARK: true
           CLUSTER_DUMP: always
-        run: bash ci/scripts/run_tests.sh -n 4 --dist loadscope ${{ env.EXTRA_OPTIONS }} ${{ matrix.pytest_args }}
+        # run: bash ci/scripts/run_tests.sh -n 4 --dist loadscope ${{ env.EXTRA_OPTIONS }} ${{ matrix.pytest_args }}
+        run: python -m pytest --run-workflows tests/workflows/test_imbalanced_join.py
 
       - name: Dump coiled.Cluster kwargs
         run: cat cluster_kwargs.merged.yaml

--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -73,6 +73,7 @@ snowflake:
 imbalanced_join:
   n_workers: 50
   worker_memory: "64 GiB"
+  scheduler_vm_types: null
   scheduler_memory: "32 GiB"
 
 # Specific tests

--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -69,6 +69,12 @@ snowflake:
   worker_vm_types: [m6i.xlarge] # 4 CPU, 16 GiB (preferred default instance)
 
 
+# For tests/workflows/test_imbalanced_join.py
+imbalanced_join:
+  n_workers: 50
+  worker_memory: "64 GiB"
+  scheduler_memory: "32 GiB"
+
 # Specific tests
 test_work_stealing_on_scaling_up:
   n_workers: 1

--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -73,8 +73,6 @@ snowflake:
 imbalanced_join:
   n_workers: 50
   worker_memory: "64 GiB"
-  scheduler_vm_types: null
-  scheduler_memory: "32 GiB"
 
 # Specific tests
 test_work_stealing_on_scaling_up:

--- a/tests/workflows/test_imbalanced_join.py
+++ b/tests/workflows/test_imbalanced_join.py
@@ -6,18 +6,19 @@ from functools import partial
 
 import dask.dataframe as dd
 import pytest
-from distributed import wait
+
+from ..utils_test import wait
 
 
 @pytest.mark.client("imbalanced_join")
 @pytest.fixture
 def dataframes(client):
     large_df = dd.read_parquet("s3://test-imbalanced-join/df1/")
-    small_df = dd.read_parquet("s3://test-imbalanced-join/df2/").persist()
+    small_df = dd.read_parquet("s3://test-imbalanced-join/df2/")
     # large dataframe has known divisions, use those
     # to ensure the data is partitioned as expected
     divisions = list(range(1, 40002, 10))
-    large_df = large_df.set_index("bucket", drop=False, divisions=divisions).persist()
+    large_df = large_df.set_index("bucket", drop=False, divisions=divisions)
     wait(large_df, client, 10 * 60)
     wait(small_df, client, 10 * 60)
     yield large_df, small_df

--- a/tests/workflows/test_imbalanced_join.py
+++ b/tests/workflows/test_imbalanced_join.py
@@ -2,21 +2,31 @@
 This data represents a skewed but realistic dataset that dask has been struggling with in the past.
 Workflow based on https://github.com/coiled/imbalanced-join/blob/main/test_big_join_synthetic.ipynb
 """
+from functools import partial
+
 import dask.dataframe as dd
 import pytest
+from distributed import wait
 
 
 @pytest.mark.client("imbalanced_join")
-def test_merge(client, shuffle_method):
-    """Merge large df and small df"""
+@pytest.fixture
+def dataframes(client):
     large_df = dd.read_parquet("s3://test-imbalanced-join/df1/")
-    small_df = dd.read_parquet("s3://test-imbalanced-join/df2/")
-
-    # this dataframe has known divisions, use those
+    small_df = dd.read_parquet("s3://test-imbalanced-join/df2/").persist()
+    # large dataframe has known divisions, use those
     # to ensure the data is partitioned as expected
     divisions = list(range(1, 40002, 10))
-    large_df = large_df.set_index("bucket", drop=False, divisions=divisions)
-    split_out = 4000  # same as number of partitions
+    large_df = large_df.set_index("bucket", drop=False, divisions=divisions).persist()
+    wait(large_df, client, 10 * 60)
+    wait(small_df, client, 10 * 60)
+    yield large_df, small_df
+
+
+@pytest.mark.client("imbalanced_join")
+def test_merge(dataframes, shuffle_method):
+    """Merge large df and small df"""
+    large_df, small_df = dataframes
 
     group_cols = ["df2_group", "bucket", "group1", "group2", "group3", "group4"]
     res = large_df.merge(
@@ -25,9 +35,18 @@ def test_merge(client, shuffle_method):
 
     # group and aggregate, use split_out so that the final data
     # chunks don't end up aggregating on a single worker
-    (
-        res.groupby(group_cols, sort=False)
-        .agg({"value": "sum"}, split_out=split_out, shuffle=shuffle_method)
-        .value.sum()
-        .compute()
-    )
+    # TODO: workers are still getting killed, even with split_out
+    # (
+    #     res.groupby(group_cols, sort=False)
+    #     .agg({"value": "sum"}, split_out=4000, shuffle=shuffle_method)
+    #     .value.sum()
+    #     .compute()
+    # )
+
+    def aggregate_partition(part, *, shuffle=None):
+        return part.groupby(group_cols, sort=False).agg(
+            {"value": "sum"}, shuffle=shuffle, split_out=100
+        )
+
+    shuffle_aggregate = partial(aggregate_partition, shuffle=shuffle_method)
+    res.map_partitions(shuffle_aggregate).value.sum().compute()

--- a/tests/workflows/test_imbalanced_join.py
+++ b/tests/workflows/test_imbalanced_join.py
@@ -1,0 +1,39 @@
+"""
+This data represents a skewed but realistic dataset that dask has been struggling with in the past.
+Workflow based on https://github.com/coiled/imbalanced-join/blob/main/test_big_join_synthetic.ipynb
+"""
+import dask.dataframe as dd
+import pytest
+from dask.distributed import wait
+
+LARGE_DF = "s3://test-imbalanced-join/df1/"
+SMALL_DF = "s3://test-imbalanced-join/df2/"
+
+
+@pytest.fixture(scope="module")
+@pytest.mark.client("imbalanced_join")
+def large_df(client):
+    """Set index on the large dataframe"""
+    df = dd.read_parquet(LARGE_DF)
+    divisions = list(range(1, 40002, 10))
+    df = df.set_index("bucket", drop=False, divisions=divisions)
+    df = df.persist()
+    wait(df)
+    yield df
+
+
+@pytest.mark.client("imbalanced_join")
+def test_merge(client, large_df):
+    """Merge large df and small df"""
+    group_cols = ["df2_group", "bucket", "group1", "group2", "group3", "group4"]
+    small_df = dd.read_parquet(SMALL_DF)
+
+    output = large_df.merge(
+        right=small_df, how="inner", on=["key", "key"], suffixes=["_l", "_r"]
+    )[group_cols + ["value"]]
+
+    def aggregate_partition(part):
+        return part.groupby(group_cols, sort=False).agg({"value": "sum"})
+
+    output = output.map_partitions(aggregate_partition)
+    output["value"].sum().compute()

--- a/tests/workflows/test_imbalanced_join.py
+++ b/tests/workflows/test_imbalanced_join.py
@@ -7,17 +7,27 @@ import pytest
 
 
 @pytest.mark.client("imbalanced_join")
-def test_merge(client):
+def test_merge(client, shuffle_method):
     """Merge large df and small df"""
     large_df = dd.read_parquet("s3://test-imbalanced-join/df1/")
     small_df = dd.read_parquet("s3://test-imbalanced-join/df2/")
 
-    group_cols = ["df2_group", "bucket", "group1", "group2", "group3", "group4"]
+    # this dataframe has known divisions, use those
+    # to ensure the data is partitioned as expected
+    divisions = list(range(1, 40002, 10))
+    large_df = large_df.set_index("bucket", drop=False, divisions=divisions)
+    split_out = 4000  # same as number of partitions
 
+    group_cols = ["df2_group", "bucket", "group1", "group2", "group3", "group4"]
     res = large_df.merge(
         right=small_df, how="inner", on=["key", "key"], suffixes=["_l", "_r"]
     )[group_cols + ["value"]]
 
-    res = res.groupby(group_cols, sort=False).agg({"value": "sum"})
-    # evaluate the whole merged dataframe
-    res["value"].sum().compute()
+    # group and aggregate, use split_out so that the final data
+    # chunks don't end up aggregating on a single worker
+    (
+        res.groupby(group_cols, sort=False)
+        .agg({"value": "sum"}, split_out=split_out, shuffle=shuffle_method)
+        .value.sum()
+        .compute()
+    )

--- a/tests/workflows/test_imbalanced_join.py
+++ b/tests/workflows/test_imbalanced_join.py
@@ -9,7 +9,7 @@ import pytest
 @pytest.mark.client("imbalanced_join")
 def test_merge(client):
     """Merge large df and small df"""
-    large_df = dd.read_parquet("s3://test-imbalanced-join/df1/key_000*.parquet")
+    large_df = dd.read_parquet("s3://test-imbalanced-join/df1/")
     small_df = dd.read_parquet("s3://test-imbalanced-join/df2/")
 
     group_cols = ["df2_group", "bucket", "group1", "group2", "group3", "group4"]

--- a/tests/workflows/test_imbalanced_join.py
+++ b/tests/workflows/test_imbalanced_join.py
@@ -7,27 +7,16 @@ from functools import partial
 import dask.dataframe as dd
 import pytest
 
-from ..utils_test import wait
-
 
 @pytest.mark.client("imbalanced_join")
-@pytest.fixture
-def dataframes(client):
+def test_merge(client, shuffle_method):
+    """Merge large df and small df"""
     large_df = dd.read_parquet("s3://test-imbalanced-join/df1/")
     small_df = dd.read_parquet("s3://test-imbalanced-join/df2/")
     # large dataframe has known divisions, use those
     # to ensure the data is partitioned as expected
     divisions = list(range(1, 40002, 10))
     large_df = large_df.set_index("bucket", drop=False, divisions=divisions)
-    wait(large_df, client, 10 * 60)
-    wait(small_df, client, 10 * 60)
-    yield large_df, small_df
-
-
-@pytest.mark.client("imbalanced_join")
-def test_merge(dataframes, shuffle_method):
-    """Merge large df and small df"""
-    large_df, small_df = dataframes
 
     group_cols = ["df2_group", "bucket", "group1", "group2", "group3", "group4"]
     res = large_df.merge(

--- a/tests/workflows/test_imbalanced_join.py
+++ b/tests/workflows/test_imbalanced_join.py
@@ -4,36 +4,23 @@ Workflow based on https://github.com/coiled/imbalanced-join/blob/main/test_big_j
 """
 import dask.dataframe as dd
 import pytest
-from dask.distributed import wait
 
 LARGE_DF = "s3://test-imbalanced-join/df1/"
 SMALL_DF = "s3://test-imbalanced-join/df2/"
 
 
-@pytest.fixture(scope="module")
 @pytest.mark.client("imbalanced_join")
-def large_df(client):
-    """Set index on the large dataframe"""
-    df = dd.read_parquet(LARGE_DF)
-    divisions = list(range(1, 40002, 10))
-    df = df.set_index("bucket", drop=False, divisions=divisions)
-    df = df.persist()
-    wait(df)
-    yield df
-
-
-@pytest.mark.client("imbalanced_join")
-def test_merge(client, large_df):
+def test_merge(client):
     """Merge large df and small df"""
-    group_cols = ["df2_group", "bucket", "group1", "group2", "group3", "group4"]
+    large_df = dd.read_parquet(LARGE_DF)
     small_df = dd.read_parquet(SMALL_DF)
 
-    output = large_df.merge(
+    group_cols = ["df2_group", "bucket", "group1", "group2", "group3", "group4"]
+
+    res = large_df.merge(
         right=small_df, how="inner", on=["key", "key"], suffixes=["_l", "_r"]
     )[group_cols + ["value"]]
 
-    def aggregate_partition(part):
-        return part.groupby(group_cols, sort=False).agg({"value": "sum"})
-
-    output = output.map_partitions(aggregate_partition)
-    output["value"].sum().compute()
+    res = res.groupby(group_cols, sort=False).agg({"value": "sum"})
+    # evaluate the whole merged dataframe
+    res["value"].sum().compute()

--- a/tests/workflows/test_imbalanced_join.py
+++ b/tests/workflows/test_imbalanced_join.py
@@ -9,7 +9,7 @@ import pytest
 @pytest.mark.client("imbalanced_join")
 def test_merge(client):
     """Merge large df and small df"""
-    large_df = dd.read_parquet("s3://test-imbalanced-join/df1/")
+    large_df = dd.read_parquet("s3://test-imbalanced-join/df1/key_000*.parquet")
     small_df = dd.read_parquet("s3://test-imbalanced-join/df2/")
 
     group_cols = ["df2_group", "bucket", "group1", "group2", "group3", "group4"]

--- a/tests/workflows/test_imbalanced_join.py
+++ b/tests/workflows/test_imbalanced_join.py
@@ -5,15 +5,12 @@ Workflow based on https://github.com/coiled/imbalanced-join/blob/main/test_big_j
 import dask.dataframe as dd
 import pytest
 
-LARGE_DF = "s3://test-imbalanced-join/df1/"
-SMALL_DF = "s3://test-imbalanced-join/df2/"
-
 
 @pytest.mark.client("imbalanced_join")
 def test_merge(client):
     """Merge large df and small df"""
-    large_df = dd.read_parquet(LARGE_DF)
-    small_df = dd.read_parquet(SMALL_DF)
+    large_df = dd.read_parquet("s3://test-imbalanced-join/df1/")
+    small_df = dd.read_parquet("s3://test-imbalanced-join/df2/")
 
     group_cols = ["df2_group", "bucket", "group1", "group2", "group3", "group4"]
 


### PR DESCRIPTION
Closes https://github.com/coiled/benchmarks/issues/882.

Benchmark for merging two dataframes, one of which is a lot bigger than the other.

Based on https://github.com/coiled/imbalanced-join/.

To clarify "imbalanced":

* "left" dataframe has a lot more records, several orders of magnitude more
* dataframes are joined by `key` column. It's a many-to-many join, with a lot more records on the left side
* data is further grouped by `group_cols`, and then aggregated. The size of groups is very uneven, with some groups containing hundreds of records, and some containing millions.