### PR TITLE
Add quadratic mean xarray workload

### DIFF
--- a/tests/benchmarks/test_array.py
+++ b/tests/benchmarks/test_array.py
@@ -141,6 +141,31 @@ def test_climatic_mean(small_client, new_array):
     wait(arr_clim, small_client, 15 * 60)
 
 
+@run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
+def test_quadratic_mean(small_client):
+    # https://github.com/pangeo-data/distributed-array-examples/issues/2
+    xr = pytest.importorskip("xarray")
+
+    ds = xr.Dataset(
+        dict(
+            anom_u=(
+                ["time", "face", "j", "i"],
+                da.random.random((5000, 1, 987, 1920), chunks=(10, 1, -1, -1)),
+            ),
+            anom_v=(
+                ["time", "face", "j", "i"],
+                da.random.random((5000, 1, 987, 1920), chunks=(10, 1, -1, -1)),
+            ),
+        )
+    )
+
+    quad = ds**2
+    quad["uv"] = ds.anom_u * ds.anom_v
+    mean = quad.mean("time")
+    # Mean is really small at this point so we can just fetch it
+    wait(mean, small_client, 15 * 60)
+
+
 def test_vorticity(small_client, new_array):
     # From https://github.com/dask/distributed/issues/6571
 


### PR DESCRIPTION
This is an xarray workload that apparently is a stereotypical example of workloads that don't run well on dask, see https://github.com/pangeo-data/distributed-array-examples/issues/2

In it's current form, it runs into a lot of spilling and runs for about 2:30min even though it _should_ be an almost embarrassingly parallel reduction. The culprit is dask.order see https://github.com/dask/dask/issues/10384 (I have a bit of a messed up order prototype where this workload runs in ~30s)

I'm not writing this test case as adaptable to cluster size. Mostly because in my experience the automatic scaling functions do not exactly what they are supposed to and I consider the value-add not worth the time tweaking this to get it into the same shape.