### PR TITLE
Avoid removing shuffle in shuffle benchmark

### DIFF
--- a/tests/benchmarks/test_dataframe.py
+++ b/tests/benchmarks/test_dataframe.py
@@ -55,7 +55,7 @@ def test_shuffle(small_client, configure_shuffling):
     print_dataframe_info(df)
     # ~25,488,000 rows x 100 columns, 19.18 GiB total, 354 55.48 MiB partitions
 
-    shuf = df.shuffle("0")
+    shuf = df.shuffle("0").map_partitions(lambda x: x)
     result = shuf.size
     wait(result, small_client, 20 * 60)
 


### PR DESCRIPTION
We are removing shuffles now when the length is computed on a DataFrame, so this test is a but pointless for dask_expr. That's the fastest op that should not remove the shuffle.