### PR TITLE
Unskip large_map_first_work

### DIFF
--- a/tests/benchmarks/test_futures.py
+++ b/tests/benchmarks/test_futures.py
@@ -34,9 +34,6 @@ def test_large_map(small_client, rootish):
 
 
 @run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
-@pytest.mark.skip(
-    reason="Skip until https://github.com/coiled/benchmarks/issues/521 is fixed"
-)
 def test_large_map_first_work(small_client):
     """
     Large maps are fine, but it's pleasant to see work start immediately.


### PR DESCRIPTION
Closes https://github.com/coiled/benchmarks/issues/521

The restart deadlock has not been fully resolved but I believe the benchmarking suite is no longer susceptible to it.