### PR TITLE
Fix `ValueError: Out of range float values are not JSON compliant` in report generation

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -442,6 +442,7 @@ def make_timeseries_html_report(
         df_by_test = df[(df.runtime == runtime) & (df.category == category)].groupby(
             "sourcename"
         )
+        df_by_test = df_by_test.fillna("")
         panes = [
             make_test_report(
                 df_by_test.get_group(sourcename),


### PR DESCRIPTION
Occasionally I find exception during the serialization of the HTML page to JSON

```python-traceback
File "/home/runner/work/benchmarks/benchmarks/dashboard.py", line 810, in <module>
    main()
  File "/home/runner/work/benchmarks/benchmarks/dashboard.py", line [78](https://github.com/coiled/benchmarks/actions/runs/6110498037/job/16586867749#step:5:79)0, in main
    make_timeseries_html_report(df, output_dir, runtime, args.ndays)
  File "/home/runner/work/benchmarks/benchmarks/dashboard.py", line 463, in make_timeseries_html_report
    doc.save(out_fname, title=runtime, resources=CDN)
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/panel/viewable.py", line 840, in save
    return save(
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/panel/io/save.py", line 289, in save
    html = file_html(doc, resources, title, **kwargs)
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/panel/io/save.py", line 157, in file_html
    (docs_json, render_items) = standalone_docs_json_and_render_items(
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/bokeh/embed/util.py", line 337, in standalone_docs_json_and_render_items
    docs_json[docid] = doc.to_json()
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/bokeh/document/document.py", line 758, in to_json
    doc_json = self.to_json_string()
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/bokeh/document/document.py", line [79](https://github.com/coiled/benchmarks/actions/runs/6110498037/job/16586867749#step:5:80)0, in to_json_string
    return serialize_json(json, indent=indent)
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/bokeh/core/json_encoder.py", line 171, in serialize_json
    return json.dumps(obj, cls=BokehJSONEncoder, allow_nan=False, indent=indent, separators=separators, sort_keys=True, **kwargs)
  File "/usr/share/miniconda3/envs/test/lib/python3.10/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/share/miniconda3/envs/test/lib/python3.10/json/encoder.py", line 1[99](https://github.com/coiled/benchmarks/actions/runs/6110498037/job/16586867749#step:5:100), in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/share/miniconda3/envs/test/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
ValueError: Out of range float values are not JSON compliant
```

I believe this is related to null values (https://stackoverflow.com/questions/38821132/bokeh-valueerror-out-of-range-float-values-are-not-json-compliant). I hope this fixes it since I cannot reproduce it.

https://github.com/coiled/benchmarks/actions/runs/6110498037/job/16586867749