### PR TITLE
Realign A/B environments to main env

### DIFF
--- a/AB_environments/AB_baseline.conda.yaml
+++ b/AB_environments/AB_baseline.conda.yaml
@@ -5,54 +5,54 @@
 channels:
   - conda-forge
 dependencies:
-    - python =3.9  # Single '=' means latest patch version available
-    # Copy-paste from ci/environment.yml
-    - pip
-    - coiled >=0.2.54
-    - numpy ==1.23.5
-    - pandas ==2.0.3
-    - dask ==2023.5.1
-    - distributed ==2023.5.1
-    - dask-labextension ==6.1.0
-    - dask-ml ==2023.3.24
-    - dask-snowflake ==0.2.0
-    - fsspec ==2023.5.0
-    - s3fs ==2023.5.0
-    - gcsfs ==2023.5.0
-    - pyarrow ==11.0.0
-    - jupyterlab ==3.6.2
-    - lz4 ==4.3.2
-    - ipywidgets ==8.0.4  # FIXME https://github.com/dask/distributed/issues/7688
-    - numba ==0.57.0
-    - scikit-learn ==1.2.2
-    - ipycytoscape ==1.3.3
-    - click ==8.1.3
-    - xarray ==2023.4.2
-    - zarr ==2.14.2
-    - cftime ==1.6.2
-    - msgpack-python ==1.0.5
-    - cloudpickle ==2.2.1
-    - tornado ==6.2
-    - toolz ==0.12.0
-    - zict ==3.0.0
-    - xgboost ==1.7.4
-    - optuna ==3.3.0
-    - scipy ==1.10.1
-    - snowflake-connector-python ==3.0.4
-    - snowflake-sqlalchemy ==1.4.7
-    - sqlalchemy ==1.4.39  # Pinned by snowflake-sqlalchemy
-    - pynvml ==11.5.0
-    - bokeh ==3.1.0
-    - gilknocker ==0.4.1
-    - openssl >1.1.0g
-    - pyopenssl ==22.1.0  # Pinned by snowflake-connector-python
-    - cryptography ==38.0.4  # Pinned by snowflake-connector-python
-    # End copy-paste
+  - python =3.9  # Single '=' means latest patch version available
+  # Copy-paste from ci/environment.yml
+  - pip
+  - coiled >=0.2.54
+  - numpy ==1.23.5
+  - pandas ==2.0.3
+  - dask ==2023.9.2
+  - distributed ==2023.9.2
+  - dask-labextension ==6.1.0
+  - dask-ml ==2023.3.24
+  - dask-snowflake ==0.2.0
+  - fsspec ==2023.5.0
+  - s3fs ==2023.5.0
+  - gcsfs ==2023.5.0
+  - pyarrow ==12.0.0
+  - jupyterlab ==3.6.2
+  - lz4 ==4.3.2
+  - ipywidgets ==8.0.4  # FIXME https://github.com/dask/distributed/issues/7688
+  - numba ==0.57.0
+  - scikit-learn ==1.2.2
+  - ipycytoscape ==1.3.3
+  - click ==8.1.3
+  - xarray ==2023.4.2
+  - zarr ==2.14.2
+  - cftime ==1.6.2
+  - msgpack-python ==1.0.5
+  - cloudpickle ==2.2.1
+  - tornado ==6.2
+  - toolz ==0.12.0
+  - zict ==3.0.0
+  - xgboost ==1.7.4
+  - optuna ==3.3.0
+  - scipy ==1.10.1
+  - snowflake-connector-python ==3.0.4
+  - snowflake-sqlalchemy ==1.4.7
+  - sqlalchemy ==1.4.39  # Pinned by snowflake-sqlalchemy
+  - pynvml ==11.5.0
+  - bokeh ==3.1.0
+  - gilknocker ==0.4.1
+  - openssl >1.1.0g
+  - pyopenssl ==22.1.0  # Pinned by snowflake-connector-python
+  - cryptography ==38.0.4  # Pinned by snowflake-connector-python
+  # End copy-paste
 
-    - pip:
-      # Make sure you install dask and distributed either both from pip or both from
-      # conda. You may alternatively point to your own git fork (but make sure you
-      # sync'ed tags!)
-      # Read README.md for troubleshooting.
-      # - git+https://github.com/dask/dask@ae39b43bdc1d7cf1b9ece112ba3dc398f3fabc13
-      # - git+https://github.com/dask/distributed@e887fde05a636864f94e7880fd301923406a3db7
+  - pip:
+    # Make sure you install dask and distributed either both from pip or both from
+    # conda. You may alternatively point to your own git fork (but make sure you
+    # sync'ed tags!)
+    # Read README.md for troubleshooting.
+    # - git+https://github.com/dask/dask@da256320ef0167992f7183c3a275d092f5727f62
+    # - git+https://github.com/dask/distributed@285893037fe9eac83f363611b4799168aabb3992

--- a/AB_environments/AB_sample.conda.yaml
+++ b/AB_environments/AB_sample.conda.yaml
@@ -10,54 +10,54 @@
 channels:
   - conda-forge
 dependencies:
-    - python =3.9  # Single '=' means latest patch version available
-    # Copy-paste from AB_baseline.conda.yaml
-    - pip
-    - coiled >=0.2.54
-    - numpy ==1.23.5
-    - pandas ==2.0.3
-    - dask ==2023.5.1
-    - distributed ==2023.5.1
-    - dask-labextension ==6.1.0
-    - dask-ml ==2023.3.24
-    - dask-snowflake ==0.2.0
-    - fsspec ==2023.5.0
-    - s3fs ==2023.5.0
-    - gcsfs ==2023.5.0
-    - pyarrow ==11.0.0
-    - jupyterlab ==3.6.2
-    - lz4 ==4.3.2
-    - ipywidgets ==8.0.4  # FIXME https://github.com/dask/distributed/issues/7688
-    - numba ==0.57.0
-    - scikit-learn ==1.2.2
-    - ipycytoscape ==1.3.3
-    - click ==8.1.3
-    - xarray ==2023.4.2
-    - zarr ==2.14.2
-    - cftime ==1.6.2
-    - msgpack-python ==1.0.5
-    - cloudpickle ==2.2.1
-    - tornado ==6.2
-    - toolz ==0.12.0
-    - zict ==3.0.0
-    - xgboost ==1.7.4
-    - optuna ==3.3.0
-    - scipy ==1.10.1
-    - snowflake-connector-python ==3.0.4
-    - snowflake-sqlalchemy ==1.4.7
-    - sqlalchemy ==1.4.39  # Pinned by snowflake-sqlalchemy
-    - pynvml ==11.5.0
-    - bokeh ==3.1.0
-    - gilknocker ==0.4.1
-    - openssl >1.1.0g
-    - pyopenssl ==22.1.0  # Pinned by snowflake-connector-python
-    - cryptography ==38.0.4  # Pinned by snowflake-connector-python
-    # End copy-paste from AB_baseline.conda.yaml
+  - python =3.9  # Single '=' means latest patch version available
+  # Copy-paste from AB_baseline.conda.yaml
+  - pip
+  - coiled >=0.2.54
+  - numpy ==1.23.5
+  - pandas ==2.0.3
+  - dask ==2023.9.2
+  - distributed ==2023.9.2
+  - dask-labextension ==6.1.0
+  - dask-ml ==2023.3.24
+  - dask-snowflake ==0.2.0
+  - fsspec ==2023.5.0
+  - s3fs ==2023.5.0
+  - gcsfs ==2023.5.0
+  - pyarrow ==12.0.0
+  - jupyterlab ==3.6.2
+  - lz4 ==4.3.2
+  - ipywidgets ==8.0.4  # FIXME https://github.com/dask/distributed/issues/7688
+  - numba ==0.57.0
+  - scikit-learn ==1.2.2
+  - ipycytoscape ==1.3.3
+  - click ==8.1.3
+  - xarray ==2023.4.2
+  - zarr ==2.14.2
+  - cftime ==1.6.2
+  - msgpack-python ==1.0.5
+  - cloudpickle ==2.2.1
+  - tornado ==6.2
+  - toolz ==0.12.0
+  - zict ==3.0.0
+  - xgboost ==1.7.4
+  - optuna ==3.3.0
+  - scipy ==1.10.1
+  - snowflake-connector-python ==3.0.4
+  - snowflake-sqlalchemy ==1.4.7
+  - sqlalchemy ==1.4.39  # Pinned by snowflake-sqlalchemy
+  - pynvml ==11.5.0
+  - bokeh ==3.1.0
+  - gilknocker ==0.4.1
+  - openssl >1.1.0g
+  - pyopenssl ==22.1.0  # Pinned by snowflake-connector-python
+  - cryptography ==38.0.4  # Pinned by snowflake-connector-python
+  # End copy-paste
 
-    - pip:
-      # Make sure you install dask and distributed either both from pip or both from
-      # conda. You may alternatively point to your own git fork (but make sure you
-      # sync'ed tags!)
-      # Read README.md for troubleshooting.
-      - git+https://github.com/dask/dask@ae39b43bdc1d7cf1b9ece112ba3dc398f3fabc13
-      - git+https://github.com/dask/distributed@e887fde05a636864f94e7880fd301923406a3db7
+  - pip:
+    # Make sure you install dask and distributed either both from pip or both from
+    # conda. You may alternatively point to your own git fork (but make sure you
+    # sync'ed tags!)
+    # Read README.md for troubleshooting.
+    - git+https://github.com/dask/dask@da256320ef0167992f7183c3a275d092f5727f62
+    - git+https://github.com/dask/distributed@285893037fe9eac83f363611b4799168aabb3992

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,8 +6,8 @@ dependencies:
   - coiled >=0.2.54
   - numpy ==1.23.5
   - pandas ==2.0.3
-  - dask ==2023.5.1
-  - distributed ==2023.5.1
+  - dask ==2023.9.2
+  - distributed ==2023.9.2
   - dask-labextension ==6.1.0
   - dask-ml ==2023.3.24
   - dask-snowflake ==0.2.0


### PR DESCRIPTION
- Bump PyArrow to 12 (follow-up to #992)
- Bump dask and distributed to a recent version. Note that, in nightly/PR CI, it's overridden by the git tip.