### PR TITLE
Add pytest-timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,12 @@ jobs:
       - name: Add test dependencies
         run: mamba env update --file ci/environment-test.yml
 
+      - name: Reconfigure pytest-timeout
+        shell: bash -l {0}
+        # No SIGALRM available on Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: sed -i.bak 's/timeout_method = signal/timeout_method = thread/' setup.cfg
+
       - name: Dump environment
         run: |
           # For debugging

--- a/ci/environment-test.yml
+++ b/ci/environment-test.yml
@@ -7,6 +7,7 @@ dependencies:
   - jinja2
   - packaging
   - pytest
+  - pytest-timeout
   - pytest-xdist
   - pyyaml
   - alembic

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,9 @@ profile = black
 addopts = -v -rsxfE --durations=0 --color=yes --strict-markers --strict-config
 markers =
     stability: marks stability tests
+# pytest-timeout settings
+# 'thread' kills off the whole test suite. 'signal' only kills the offending test.
+# However, 'signal' doesn't work on Windows (due to lack of SIGALRM).
+# The 'tests' CI script modifies this config file on the fly for Windows clients.
+timeout_method = signal
+timeout = 1200


### PR DESCRIPTION
Individually fail hung tests and continue. 
Before this, the whole test suite would hang, only to die 2 hours later on the github actions timeout with no indication of which was the offending test.

Known issue: a hung test killed this way won't produce a cluster dump.