### PR TITLE
[DNM] Use (feature-flagged) AWS creds endpoint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,7 @@ dask.config.set(
     {
         "coiled.account": "dask-benchmarks",
         "distributed.admin.system-monitor.gil.enabled": True,
+        "coiled.use_aws_creds_endpoint": True,
     }
 )
 


### PR DESCRIPTION
I don't expect any issues, but this is easy way to confirm that this works with all the ways we rely on AWS creds here.