### PR TITLE
Faster skip for H2O tests

### DIFF
--- a/tests/benchmarks/test_h2o.py
+++ b/tests/benchmarks/test_h2o.py
@@ -37,11 +37,13 @@ else:
     }
 
 
-@pytest.fixture(params=list(DATASETS))
-def ddf(request, small_client):
-    if request.param not in enabled_datasets:
-        raise pytest.skip("Disabled by default config or H2O_DATASETS env variable")
+@pytest.mark.fixture(autouse=True)
+def client(small_client):
+    yield small_client
 
+
+@pytest.fixture(params=list(enabled_datasets), scope="module")
+def ddf(request):
     n_gib = float(request.param.split(" GB ")[0])
     # 0.5 GB datasets are broken in 5~10 files
     # 5 GB -> 100 files

--- a/tests/benchmarks/test_h2o.py
+++ b/tests/benchmarks/test_h2o.py
@@ -42,7 +42,7 @@ def client(small_client):
     yield small_client
 
 
-@pytest.fixture(params=list(enabled_datasets), scope="module")
+@pytest.fixture(params=sorted(enabled_datasets), scope="module")
 def ddf(request):
     n_gib = float(request.param.split(" GB ")[0])
     # 0.5 GB datasets are broken in 5~10 files


### PR DESCRIPTION
The current implementation generates a test case for all possible defined Datasets. This is not necessary since we can directly just generate those that are enabled.

Either way, if we decide to skip, the skip should be implemented in a fixture further up the DAG. By having `ddf` depend on `small_client`, it will execute `small_client` every time, i.e. it will connect a new client and restart the cluster just to enter `ddf` and decide to skip.
Considering that 6 out of 9 datasets are skipped and there are 9 test cases, this gives us 54 unnecessary client connections + 2 restarts.

This fixes both...