### PR TITLE
Fix PyTorch Optuna

### DIFF
--- a/tests/workflows/test_pytorch_optuna.py
+++ b/tests/workflows/test_pytorch_optuna.py
@@ -19,15 +19,16 @@ optuna = pytest.importorskip("optuna")
             # FIXME https://github.com/coiled/platform/issues/1249
             #       package_sync doesn't seem to deduce GPU specific installs of
             #       libraries like torch
-            "torch==2.0.0",
+            "torch",
             # FIXME Windows package_sync doesn't like torchvision
-            "torchvision==0.15.1",
+            "torchvision",
             # FIXME https://github.com/boto/botocore/issues/2926
             #       urllib3 v2 removed openssl / ciphers which causes an error in
             #       botocore httpsession
             "urllib3<2.0.0",
         ],
         pip_options=["--force-reinstall"],
+        restart_workers=True,
     ),
 )
 def test_hpo(client):

--- a/tests/workflows/test_pytorch_optuna.py
+++ b/tests/workflows/test_pytorch_optuna.py
@@ -28,7 +28,6 @@ optuna = pytest.importorskip("optuna")
             "urllib3<2.0.0",
         ],
         pip_options=["--force-reinstall"],
-        restart=True,
     ),
 )
 def test_hpo(client):

--- a/tests/workflows/test_pytorch_optuna.py
+++ b/tests/workflows/test_pytorch_optuna.py
@@ -11,7 +11,6 @@ from ..utils_test import wait
 optuna = pytest.importorskip("optuna")
 
 
-@pytest.mark.xfail(reason="https://github.com/coiled/benchmarks/issues/969")
 @pytest.mark.client(
     "pytorch_optuna",
     worker_plugin=PipInstall(


### PR DESCRIPTION
Will close #1047, close #1048, close #1049, close #1051
Removing the torch pinning also fixes it apparently not running on GPU, which also turns out to close #969; in that issue it was reported that 60 trials were ran, trying again before this fix it was 57; might be some semi-randomness to amount of trials being accomplished when running on CPU(?). Ran twice (and once more here in this PR) and it passes with the expected 50 trials.