### PR TITLE
Don't skip all tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,12 +72,12 @@ def pytest_collection_modifyitems(config, items):
 
     skip_benchmarks = pytest.mark.skip(reason="need --tpch-non-dask option to run")
     for item in items:
-        if not config.getoption("--tpch-non-dask") and not (
-            str(item.path).startswith(
-                str(TEST_DIR / "benchmarks" / "tpch" / "test_dask")
-            )
-        ):
-            item.add_marker(skip_benchmarks)
+        if "tpch" in str(item.path):
+            # Skip polars and DuckDB TPCH unless this toggle is on
+            if "test_dask" not in str(item.path) and not config.getoption(
+                "--tpch-non-dask"
+            ):
+                item.add_marker(skip_benchmarks)
 
 
 dask.config.set(


### PR DESCRIPTION
This toggle caused us to skip all tests and just run the TCPH dask benchmarks.

This toggle will either be obsolete or has to change after https://github.com/coiled/benchmarks/issues/1099 is done