### PR TITLE
Add migration for tpch tests restructure from #1094 and #1044

### DIFF
--- a/alembic/versions/87cbf883c2be_update_tpch_refactor_from_1094.py
+++ b/alembic/versions/87cbf883c2be_update_tpch_refactor_from_1094.py
@@ -1,0 +1,36 @@
+"""Update tpch refactor from #1094
+
+Revision ID: 87cbf883c2be
+Revises: b0e8d5f3295d
+Create Date: 2023-10-18 20:31:17.848799
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "87cbf883c2be"
+down_revision = "b0e8d5f3295d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        update test_run
+        set path = substr(path, length('benchmarks/') + 1)
+        where path like 'benchmarks/tpch/%';
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        update test_run
+        set path = 'benchmarks/' || path
+        where path like 'tpch/%';
+        """
+    )

--- a/alembic/versions/b0e8d5f3295d_update_test_tpch_tpch_test_dask_from_.py
+++ b/alembic/versions/b0e8d5f3295d_update_test_tpch_tpch_test_dask_from_.py
@@ -1,0 +1,36 @@
+"""Update test_tpch -> tpch/test_dask from #1044
+
+Revision ID: b0e8d5f3295d
+Revises: 778e617a2886
+Create Date: 2023-10-18 20:14:47.476804
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b0e8d5f3295d'
+down_revision = '778e617a2886'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        update test_run
+        set path = 'benchmarks/tpch/test_dask.py'
+        where path = 'benchmarks/test_tpch.py'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        update test_run
+        set path = 'benchmarks/test_tpch.py'
+        where path = 'benchmarks/tpch/test_dask.py'
+        """
+    )


### PR DESCRIPTION
Manually checked this out from the benchmark db on S3; after migration is applied:

![image](https://github.com/coiled/benchmarks/assets/13764397/569cf010-cc85-4707-938d-84a8052ebfc1)
