### PR TITLE
Clean up and remove a few long tests

### DIFF
--- a/alembic/versions/78c6e00fee88_remove_task_based_shuffle.py
+++ b/alembic/versions/78c6e00fee88_remove_task_based_shuffle.py
@@ -1,0 +1,46 @@
+"""Remove task based shuffle
+
+Revision ID: 78c6e00fee88
+Revises: 778e617a2886
+Create Date: 2023-10-19 15:26:04.281985
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "78c6e00fee88"
+down_revision = "778e617a2886"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        delete from test_run
+        where (
+               originalname in ('test_shuffle')
+               or name in ('test_join_big[1-tasks]', 'test_join_big[0.1-tasks]')
+            )
+        """
+    )
+    op.execute(
+        """
+        update test_run
+        set name = 'test_join_big[1]'
+        where name == 'test_join_big[1-p2p]';
+        """
+    )
+    op.execute(
+        """
+        update test_run
+        set name = 'test_join_big[0.1]'
+        where name == 'test_join_big[0.1-p2p]';
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/versions/78c6e00fee88_remove_task_based_shuffle.py
+++ b/alembic/versions/78c6e00fee88_remove_task_based_shuffle.py
@@ -22,7 +22,8 @@ def upgrade() -> None:
         delete from test_run
         where (
                originalname in ('test_shuffle', 'test_cluster_reconnect')
-               or name in ('test_join_big[1-tasks]', 'test_join_big[0.1-tasks]')
+               or name like 'test_join_big[%tasks%]'
+               or name like 'test_set_index[%tasks%]'
             )
         """
     )
@@ -40,6 +41,15 @@ def upgrade() -> None:
         where name == 'test_join_big[0.1-p2p]';
         """
     )
+    for b in [True, False]:
+        for factor in [0.1, 1]:
+            op.execute(
+            f"""
+                update test_run
+                set name = 'test_set_index[{factor}-{b}]'
+                where name == 'test_set_index[{factor}-p2p-{b}]';
+                """
+            )
 
 
 def downgrade() -> None:

--- a/alembic/versions/78c6e00fee88_remove_task_based_shuffle.py
+++ b/alembic/versions/78c6e00fee88_remove_task_based_shuffle.py
@@ -21,7 +21,7 @@ def upgrade() -> None:
         """
         delete from test_run
         where (
-               originalname in ('test_shuffle')
+               originalname in ('test_shuffle', 'test_cluster_reconnect')
                or name in ('test_join_big[1-tasks]', 'test_join_big[0.1-tasks]')
             )
         """

--- a/tests/benchmarks/test_dataframe.py
+++ b/tests/benchmarks/test_dataframe.py
@@ -42,24 +42,6 @@ def test_dataframe_align(small_client):
     wait(final, small_client, 10 * 60)
 
 
-def test_shuffle(small_client, configure_shuffling, memory_multiplier):
-    memory = cluster_memory(small_client)  # 76.66 GiB
-
-    df = timeseries_of_size(
-        memory * memory_multiplier,
-        start="2020-01-01",
-        freq="1200ms",
-        partition_freq="24h",
-        dtypes={str(i): float for i in range(100)},
-    )
-    print_dataframe_info(df)
-    # ~25,488,000 rows x 100 columns, 19.18 GiB total, 354 55.48 MiB partitions
-
-    shuf = df.shuffle("0").map_partitions(lambda x: x)
-    result = shuf.size
-    wait(result, small_client, 20 * 60)
-
-
 def test_filter(small_client):
     """How fast can we filter a DataFrame?"""
     memory = cluster_memory(small_client)

--- a/tests/benchmarks/test_join.py
+++ b/tests/benchmarks/test_join.py
@@ -5,7 +5,7 @@ from ..utils_test import cluster_memory, run_up_to_nthreads, timeseries_of_size,
 
 
 @run_up_to_nthreads("small_cluster", 40, reason="Does not finish")
-def test_join_big(small_client, memory_multiplier, configure_shuffling):
+def test_join_big(small_client, memory_multiplier):
     memory = cluster_memory(small_client)  # 76.66 GiB
 
     df1_big = timeseries_of_size(
@@ -54,7 +54,7 @@ def test_join_big_small(small_client, memory_multiplier, configure_shuffling):
 
 
 @pytest.mark.parametrize("persist", [True, False])
-def test_set_index(small_client, persist, memory_multiplier, configure_shuffling):
+def test_set_index(small_client, persist, memory_multiplier):
     memory = cluster_memory(small_client)  # 76.66 GiB
 
     df_big = timeseries_of_size(

--- a/tests/runtime/test_cluster_creation.py
+++ b/tests/runtime/test_cluster_creation.py
@@ -15,7 +15,6 @@ def test_default_cluster_spinup_time(
         with Cluster(
             name=f"test_default_cluster_spinup_time-{uuid.uuid4().hex[:8]}",
             n_workers=1,
-            package_sync=True,
             tags=github_cluster_tags,
         ) as cluster:
             with get_cluster_info(cluster):

--- a/tests/runtime/test_coiled.py
+++ b/tests/runtime/test_coiled.py
@@ -1,8 +1,0 @@
-from coiled import Cluster
-
-
-def test_cluster_reconnect(small_cluster, get_cluster_info, benchmark_time):
-    """How quickly can we reconnect to an existing cluster?"""
-    with get_cluster_info(small_cluster), benchmark_time:
-        with Cluster(name=small_cluster.name, shutdown_on_close=False):
-            pass


### PR DESCRIPTION
I spent ten minutes going through benchmarks and seeing what we could remove.  There were two main approaches things here:

1.  Go through the more expensive tests from a previous run
2.  Go through tests/benchmarks/runtime to see if we actually cared about those

I've removed a few.  This is by no means comprehensive or well thought through.  I'm curious how easy it is for us to make changes here.