### PR TITLE
Limit dashboard to last 30 days

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -743,7 +743,8 @@ def main() -> None:
     engine = sqlalchemy.create_engine(f"sqlite:///{args.db_file}")
     df = pandas.read_sql(
         "select * from test_run where platform = 'linux' "
-        "and call_outcome in ('passed', 'failed')",
+        "and call_outcome in ('passed', 'failed')"
+        "and start >= (select datetime('now', -30 day'))",
         engine,
     )
     df = df.assign(

--- a/dashboard.py
+++ b/dashboard.py
@@ -744,7 +744,7 @@ def main() -> None:
     df = pandas.read_sql(
         "select * from test_run where platform = 'linux' "
         "and call_outcome in ('passed', 'failed')"
-        "and start >= (select datetime('now', -30 day'))",
+        "and start >= datetime('now', -30 day')",
         engine,
     )
     df = df.assign(

--- a/dashboard.py
+++ b/dashboard.py
@@ -744,7 +744,7 @@ def main() -> None:
     df = pandas.read_sql(
         "select * from test_run where platform = 'linux' "
         "and call_outcome in ('passed', 'failed')"
-        "and start >= datetime('now', -30 day')",
+        "and start >= datetime('now', '-30 day')",
         engine,
     )
     df = df.assign(


### PR DESCRIPTION
This reduces the generated files' size from 150 MB to 20 MB and automatically eliminates stale tests from the dashboard.