### PR TITLE
Support TPC-H gen on dask/coiled

### DIFF
--- a/tests/tpch/generate-data.py
+++ b/tests/tpch/generate-data.py
@@ -47,7 +47,8 @@ def generate(
     if use_coiled:
         with coiled.Cluster(
             n_workers=10,
-            worker_memory="4 GiB",
+            # workload is best with 1vCPU and ~3-4GiB memory
+            worker_vm_types=["m7a.medium", "m3.medium"],
             worker_options={"nthreads": 1},
             region=REGION,
         ) as cluster:

--- a/tests/tpch/generate-data.py
+++ b/tests/tpch/generate-data.py
@@ -58,7 +58,7 @@ def _generate_via_cluster(cluster, scale, path, relaxed_schema, partition_size):
         jobs = []
         for step in range(0, scale):
             job = client.submit(
-                _dbgen_to_path,
+                _tpch_data_gen,
                 scale=scale,
                 step=step,
                 path=path,
@@ -84,7 +84,7 @@ def retry(f):
 
 
 @retry
-def _dbgen_to_path(
+def _tpch_data_gen(
     scale: int, path: str, partition_size: str, relaxed_schema: bool, step: int
 ):
     """

--- a/tests/tpch/generate-data.py
+++ b/tests/tpch/generate-data.py
@@ -21,10 +21,13 @@ def generate(
 ):
     if str(path).startswith("s3"):
         path += "/" if not path.endswith("/") else ""
-        path += f"scale-{scale}/"
+        path += f"scale-{scale}{'-strict' if not relaxed_schema else ''}/"
         use_coiled = True
     else:
-        path = pathlib.Path(path) / f"scale-{scale}/"
+        path = (
+            pathlib.Path(path)
+            / f"scale-{scale}{'-strict' if not relaxed_schema else ''}/"
+        )
         path.mkdir(parents=True, exist_ok=True)
         use_coiled = False
 
@@ -32,7 +35,10 @@ def generate(
 
     if use_coiled:
         with coiled.Cluster(
-            n_workers=10, worker_memory="4 GiB", worker_options={"nthreads": 1}
+            n_workers=10,
+            worker_memory="4 GiB",
+            worker_options={"nthreads": 1},
+            region="us-east-2",
         ) as cluster:
             cluster.adapt(minimum=1, maximum=250)
             client = cluster.get_client()


### PR DESCRIPTION
Propose to add generation of TPC-H data using Coiled when the path is an S3 bucket. 
Edits to generate each step in the scale separately. 
I've ran this for scales 100 and 1000. For reference, the scale 1000 took just 8 minutes with this cluster: https://cloud.coiled.io/clusters/297474/information?account=dask-engineering&tab=Metrics&cpu_variation=Worker+Distribution

The scales generated so far with this are in the `s3://coiled-runtime-ci/tpch/scratch/scale-{100, 1000}` directories. I think this enables us to generate the larger scales pretty easily.