### PR TITLE
Update TPCH Infrastructure

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -41,4 +41,5 @@ dependencies:
   - pyspark ==3.4.1
   - openjdk ==20.0.2
   - python-duckdb ==0.9.1
-  - polars >=0.19.3,<=0.19.9  # 0.19.3 on Windows, 0.19.9 on Linux and MacOS
+  - polars >=0.19.3,<=0.19.10  # 0.19.3 on Windows, 0.19.10 on Linux and MacOS
+  - altair

--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -53,18 +53,6 @@ uber_lyft_large:
   n_workers: 50
   worker_vm_types: [m6i.xlarge] # 4 CPU, 16 GiB (preferred default instance)
 
-tpch:
-  n_workers: 8
-  scheduler_vm_types: [m6i.xlarge]
-  worker_vm_types: [m6i.xlarge] # 4 CPU, 16 GiB (preferred default instance)
-  scheduler_options:
-    idle_timeout: '1h' # Spark idleness not implemented yet
-  spot_policy: 'on-demand'
-  backend_options:
-   ingress:
-     - ports: [443, 8786, 8787, 7077, 8080, 4040, 15002]
-       cidr: "0.0.0.0/0"
-
 # For tests/workflows/test_pytorch_optuna.py
 pytorch_optuna:
   n_workers: 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ skip = alembic
 profile = black
 
 [tool:pytest]
-addopts = -v -rsxfE --durations=0 --color=yes --strict-markers --strict-config
+addopts = -v -rsxfE --durations=0 --color=yes --strict-markers --strict-config --dist loadscope
 markers =
     stability: marks stability tests
 # pytest-timeout settings
@@ -22,4 +22,4 @@ markers =
 # However, 'signal' doesn't work on Windows (due to lack of SIGALRM).
 # The 'tests' CI script modifies this config file on the fly for Windows clients.
 timeout_method = signal
-timeout = 1200
+timeout = 3600

--- a/tests/tpch/conftest.py
+++ b/tests/tpch/conftest.py
@@ -1,10 +1,14 @@
+import contextlib
+import datetime
 import os
+import time
 import uuid
 
 import coiled
 import dask
+import filelock
 import pytest
-from dask.distributed import LocalCluster
+from dask.distributed import LocalCluster, performance_report
 
 ##################
 # Global Options #
@@ -13,14 +17,24 @@ from dask.distributed import LocalCluster
 
 def pytest_addoption(parser):
     parser.addoption("--local", action="store_true", default=False, help="")
+    parser.addoption("--cloud", action="store_false", dest="local", help="")
     parser.addoption("--restart", action="store_true", default=True, help="")
     parser.addoption("--no-restart", action="store_false", dest="restart", help="")
+    parser.addoption(
+        "--performance-report", action="store_true", default=False, help=""
+    )
 
     parser.addoption(
         "--scale",
         action="store",
         default=10,
         help="Scale to run, 10, 100, 1000, or 10000",
+    )
+    parser.addoption(
+        "--name",
+        action="store",
+        default="",
+        help="Name to use for run",
     )
 
 
@@ -44,10 +58,13 @@ def dataset_path(local, scale):
     remote_paths = {
         10: "s3://coiled-runtime-ci/tpch/scale-10/",
         100: "s3://coiled-runtime-ci/tpch/scale-100/",
+        # 1000: "s3://coiled-runtime-ci/tpc-h/scale-1000/",
         1000: "s3://coiled-runtime-ci/tpch/scale-1000/",
-        10000: "s3://coiled-runtime-ci/tpch/scale-10000/",
+        10000: "s3://coiled-runtime-ci/tpc-h/scale-10000/",
+        # 10000: "s3://coiled-runtime-ci/tpch/scale-10000/",
     }
     local_paths = {
+        1: "./tpch-data/scale-1/",
         10: "./tpch-data/scale10/",
         100: "./tpch-data/scale100/",
     }
@@ -65,25 +82,138 @@ def module(request):
     return module
 
 
+@pytest.fixture(scope="function")
+def query(request):
+    if request.node.name.startswith("test_query_"):
+        return int(request.node.name.split("_")[-1])
+    else:
+        return None
+
+
+@pytest.fixture(scope="session")
+def name(request, tmp_path_factory, worker_id):
+    if request.config.getoption("name"):
+        return request.config.getoption("name")
+
+    if worker_id == "master":
+        # not executing in with multiple workers
+        return uuid.uuid4().hex[:8]
+
+    # get the temp directory shared by all workers
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+
+    fn = root_tmp_dir / "data"
+    with filelock.FileLock(str(fn) + ".lock"):
+        if fn.is_file():
+            data = fn.read_text()
+        else:
+            data = uuid.uuid4().hex[:8]
+            fn.write_text(data)
+    return data
+
+
+@pytest.fixture(scope="function")
+def benchmark_time(test_run_benchmark, module, scale, name):
+    """Benchmark the wall clock time of executing some code.
+
+    Yields
+    ------
+    Context manager that records the wall clock time duration of executing
+    the ``with`` statement if run as part of a benchmark, or does nothing otherwise.
+
+    Example
+    -------
+    .. code-block:: python
+
+        def test_something(benchmark_time):
+            with benchmark_time:
+                do_something()
+    """
+
+    @contextlib.contextmanager
+    def _benchmark_time():
+        if not test_run_benchmark:
+            yield
+        else:
+            start = time.time()
+            yield
+            end = time.time()
+            test_run_benchmark.duration = end - start
+            test_run_benchmark.start = datetime.datetime.utcfromtimestamp(start)
+            test_run_benchmark.end = datetime.datetime.utcfromtimestamp(end)
+            test_run_benchmark.cluster_name = f"tpch-{module}-{scale}-{name}"
+
+    return _benchmark_time()
+
+
 #############################################
 # Multi-machine fixtures for Spark and Dask #
 #############################################
 
 
+@pytest.fixture(scope="session")
+def cluster_spec(scale):
+    everywhere = dict(
+        idle_timeout="1h",
+        wait_for_workers=True,
+        scheduler_vm_types=["m6i.xlarge"],
+        backend_options={
+            "ingress": [
+                {
+                    "ports": [443, 8786, 8787, 7077, 8080, 4040, 15002],
+                    "cidr": "0.0.0.0/0",
+                },
+            ],
+        },
+    )
+    if scale == 10:
+        return {
+            "worker_vm_types": ["m6i.large"],
+            "n_workers": 16,
+            **everywhere,
+        }
+    elif scale == 100:
+        return {
+            "worker_vm_types": ["m6i.large"],
+            "n_workers": 16,
+            **everywhere,
+        }
+    elif scale == 1000:
+        return {
+            "worker_vm_types": ["m6i.large"],
+            "n_workers": 32,
+            **everywhere,
+        }
+    elif scale == 10000:
+        return {
+            "worker_vm_types": ["m6i.2xlarge"],
+            "n_workers": 64,
+            "worker_disk_size": 100,
+            **everywhere,
+        }
+
+
 @pytest.fixture(scope="module")
 def cluster(
-    local, scale, module, dask_env_variables, cluster_kwargs, github_cluster_tags
+    local,
+    scale,
+    module,
+    dask_env_variables,
+    cluster_spec,
+    github_cluster_tags,
+    name,
+    make_chart,
 ):
     if local:
         with LocalCluster() as cluster:
             yield cluster
     else:
         kwargs = dict(
-            name=f"tpch-{module}-{scale}-{uuid.uuid4().hex[:8]}",
+            name=f"tpch-{module}-{scale}-{name}",
             environ=dask_env_variables,
             tags=github_cluster_tags,
             region="us-east-2",
-            **cluster_kwargs["tpch"],
+            **cluster_spec,
         )
         with dask.config.set({"distributed.scheduler.worker-saturation": "inf"}):
             with coiled.Cluster(**kwargs) as cluster:
@@ -91,14 +221,36 @@ def cluster(
 
 
 @pytest.fixture
-def client(request, cluster, testrun_uid, cluster_kwargs, benchmark_all, restart):
+def client(
+    request,
+    cluster,
+    testrun_uid,
+    cluster_kwargs,
+    benchmark_time,
+    restart,
+    scale,
+    local,
+    query,
+):
     with cluster.get_client() as client:
         if restart:
             client.restart()
         client.run(lambda: None)
 
-        with benchmark_all(client):
-            yield client
+        local = "local" if local else "cloud"
+        if request.config.getoption("--performance-report"):
+            if not os.path.exists("performance-reports"):
+                os.mkdir("performance-reports")
+            with performance_report(
+                filename=os.path.join(
+                    "performance-reports", f"{local}-{scale}-{query}.html"
+                )
+            ):
+                with benchmark_time:
+                    yield client
+        else:
+            with benchmark_time:
+                yield client
 
 
 @pytest.fixture(scope="module")
@@ -136,20 +288,54 @@ def spark(spark_setup, benchmark_time):
     spark_setup.catalog.clearCache()
 
 
+@pytest.fixture
+def fs(local):
+    if local:
+        return None
+    else:
+        import boto3
+        from pyarrow.fs import S3FileSystem
+
+        session = boto3.session.Session()
+        credentials = session.get_credentials()
+
+        fs = S3FileSystem(
+            secret_key=credentials.secret_key,
+            access_key=credentials.access_key,
+            region="us-east-2",
+            session_token=credentials.token,
+        )
+        return fs
+
+
 #################################################
 # Single machine fixtures for Polars and DuckDB #
 #################################################
 
 
-machine = {  # TODO: figure out where to place this
-    "vm_type": "m6i.8xlarge",
-}
-
-_uuid = uuid.uuid4().hex[:8]
+@pytest.fixture(scope="session")
+def machine_spec(scale):
+    if scale == 10:
+        return {
+            "vm_type": "m6i.8xlarge",
+        }
+    elif scale <= 100:
+        return {
+            "vm_type": "m6i.8xlarge",
+        }
+    elif scale == 1000:
+        return {
+            "vm_type": "m6i.16xlarge",
+        }
+    elif scale == 10000:
+        return {
+            "vm_type": "m6i.32xlarge",
+            "disk_size": 1000,
+        }
 
 
 @pytest.fixture(scope="module")
-def module_run(local, module, scale):
+def module_run(local, module, scale, name, machine_spec):
     if local:
 
         def _run(function):
@@ -159,7 +345,7 @@ def module_run(local, module, scale):
 
     else:
 
-        @coiled.function(**machine, name=f"tpch-{module}-{scale}-{_uuid}")
+        @coiled.function(**machine_spec, name=f"tpch-{module}-{scale}-{name}")
         def _run(function):
             return function()
 
@@ -177,9 +363,36 @@ def warm_start(module_run, local):
 
 
 @pytest.fixture(scope="function")
-def run(module_run, restart, benchmark_time, warm_start):
+def run(module_run, restart, benchmark_time, warm_start, make_chart):
     if restart and not local:
         module_run.client.restart()
 
     with benchmark_time:
         yield module_run
+
+
+#############
+# Charting #
+#############
+
+
+@pytest.fixture(scope="session")
+def make_chart(name, tmp_path_factory, local, scale):
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+    lock = filelock.FileLock(root_tmp_dir / "tpch.lock")
+
+    local = "local" if local else "cloud"
+
+    if not os.path.exists("charts"):
+        os.mkdir("charts")
+
+    try:
+        yield
+    finally:
+        from .generate_plot import generate
+
+        with lock:
+            generate(
+                outfile=os.path.join("charts", f"{local}-{scale}-query-{name}.json"),
+                name=name,
+            )

--- a/tests/tpch/conftest.py
+++ b/tests/tpch/conftest.py
@@ -56,12 +56,10 @@ def restart(request):
 @pytest.fixture(scope="session")
 def dataset_path(local, scale):
     remote_paths = {
-        10: "s3://coiled-runtime-ci/tpch/scale-10/",
-        100: "s3://coiled-runtime-ci/tpch/scale-100/",
-        # 1000: "s3://coiled-runtime-ci/tpc-h/scale-1000/",
-        1000: "s3://coiled-runtime-ci/tpch/scale-1000/",
+        10: "s3://coiled-runtime-ci/tpc-h/scale-10/",
+        100: "s3://coiled-runtime-ci/tpc-h/scale-100/",
+        1000: "s3://coiled-runtime-ci/tpc-h/scale-1000/",
         10000: "s3://coiled-runtime-ci/tpc-h/scale-10000/",
-        # 10000: "s3://coiled-runtime-ci/tpch/scale-10000/",
     }
     local_paths = {
         1: "./tpch-data/scale-1/",
@@ -319,7 +317,7 @@ def machine_spec(scale):
         return {
             "vm_type": "m6i.8xlarge",
         }
-    elif scale <= 100:
+    elif scale == 100:
         return {
             "vm_type": "m6i.8xlarge",
         }
@@ -395,4 +393,5 @@ def make_chart(name, tmp_path_factory, local, scale):
             generate(
                 outfile=os.path.join("charts", f"{local}-{scale}-query-{name}.json"),
                 name=name,
+                scale=scale,
             )

--- a/tests/tpch/generate_plot.py
+++ b/tests/tpch/generate_plot.py
@@ -3,7 +3,7 @@ import click
 import pandas as pd
 
 
-def generate(outfile="chart.json", name=None):
+def generate(outfile="chart.json", name=None, scale=None):
     df = pd.read_sql_table(table_name="test_run", con="sqlite:///benchmark.db")
 
     df = df[
@@ -23,6 +23,9 @@ def generate(outfile="chart.json", name=None):
     if name:
         df = df[df.name == name]
 
+    if scale:
+        df = df[df.scale == scale]
+
     df = df.sort_values(["query", "library"])
 
     def recent(df):
@@ -30,8 +33,6 @@ def generate(outfile="chart.json", name=None):
 
     df = df.groupby(["library", "query"]).apply(recent).reset_index(drop=True)
     del df["start"]
-
-    assert df.scale.nunique() == 1
 
     chart = (
         alt.Chart(df)
@@ -42,7 +43,7 @@ def generate(outfile="chart.json", name=None):
             xOffset="library:N",
             color=alt.Color("library").scale(
                 domain=["dask", "duckdb", "polars", "pyspark"],
-                range=["#5677a4", "#e68b39", "#d4605b", "green"],
+                range=["#5677a4ff", "#e68b39ff", "#d4605bff", "#82b5b2ff"],
             ),
             tooltip=["library", "duration"],
         )

--- a/tests/tpch/test_dask.py
+++ b/tests/tpch/test_dask.py
@@ -3,9 +3,9 @@ from datetime import datetime
 import dask_expr as dd
 
 
-def test_query_1(client, dataset_path):
+def test_query_1(client, dataset_path, fs):
     VAR1 = datetime(1998, 9, 2)
-    lineitem_ds = dd.read_parquet(dataset_path + "lineitem")
+    lineitem_ds = dd.read_parquet(dataset_path + "lineitem", filesystem=fs)
 
     lineitem_filtered = lineitem_ds[lineitem_ds.l_shipdate <= VAR1]
     lineitem_filtered["sum_qty"] = lineitem_filtered.l_quantity
@@ -40,16 +40,16 @@ def test_query_1(client, dataset_path):
     total.reset_index().sort_values(["l_returnflag", "l_linestatus"]).compute()
 
 
-def test_query_2(client, dataset_path):
+def test_query_2(client, dataset_path, fs):
     var1 = 15
     var2 = "BRASS"
     var3 = "EUROPE"
 
-    region_ds = dd.read_parquet(dataset_path + "region")
-    nation_filtered = dd.read_parquet(dataset_path + "nation")
-    supplier_filtered = dd.read_parquet(dataset_path + "supplier")
-    part_filtered = dd.read_parquet(dataset_path + "part")
-    partsupp_filtered = dd.read_parquet(dataset_path + "partsupp")
+    region_ds = dd.read_parquet(dataset_path + "region", filesystem=fs)
+    nation_filtered = dd.read_parquet(dataset_path + "nation", filesystem=fs)
+    supplier_filtered = dd.read_parquet(dataset_path + "supplier", filesystem=fs)
+    part_filtered = dd.read_parquet(dataset_path + "part", filesystem=fs)
+    partsupp_filtered = dd.read_parquet(dataset_path + "partsupp", filesystem=fs)
 
     region_filtered = region_ds[(region_ds["r_name"] == var3)]
     r_n_merged = nation_filtered.merge(
@@ -108,13 +108,13 @@ def test_query_2(client, dataset_path):
     )
 
 
-def test_query_3(client, dataset_path):
+def test_query_3(client, dataset_path, fs):
     var1 = datetime.strptime("1995-03-15", "%Y-%m-%d")
     var2 = "BUILDING"
 
-    lineitem_ds = dd.read_parquet(dataset_path + "lineitem")
-    orders_ds = dd.read_parquet(dataset_path + "orders")
-    cutomer_ds = dd.read_parquet(dataset_path + "customer")
+    lineitem_ds = dd.read_parquet(dataset_path + "lineitem", filesystem=fs)
+    orders_ds = dd.read_parquet(dataset_path + "orders", filesystem=fs)
+    cutomer_ds = dd.read_parquet(dataset_path + "customer", filesystem=fs)
 
     lsel = lineitem_ds.l_shipdate > var1
     osel = orders_ds.o_orderdate < var1
@@ -133,12 +133,12 @@ def test_query_3(client, dataset_path):
     ]
 
 
-def test_query_4(client, dataset_path):
+def test_query_4(client, dataset_path, fs):
     date1 = datetime.strptime("1993-10-01", "%Y-%m-%d")
     date2 = datetime.strptime("1993-07-01", "%Y-%m-%d")
 
-    line_item_ds = dd.read_parquet(dataset_path + "lineitem")
-    orders_ds = dd.read_parquet(dataset_path + "orders")
+    line_item_ds = dd.read_parquet(dataset_path + "lineitem", filesystem=fs)
+    orders_ds = dd.read_parquet(dataset_path + "orders", filesystem=fs)
 
     lsel = line_item_ds.l_commitdate < line_item_ds.l_receiptdate
     osel = (orders_ds.o_orderdate < date1) & (orders_ds.o_orderdate >= date2)
@@ -156,16 +156,16 @@ def test_query_4(client, dataset_path):
     result_df.rename(columns={"o_orderkey": "order_count"}).compute()
 
 
-def test_query_5(client, dataset_path):
+def test_query_5(client, dataset_path, fs):
     date1 = datetime.strptime("1994-01-01", "%Y-%m-%d")
     date2 = datetime.strptime("1995-01-01", "%Y-%m-%d")
 
-    region_ds = dd.read_parquet(dataset_path + "region")
-    nation_ds = dd.read_parquet(dataset_path + "nation")
-    customer_ds = dd.read_parquet(dataset_path + "customer")
-    line_item_ds = dd.read_parquet(dataset_path + "lineitem")
-    orders_ds = dd.read_parquet(dataset_path + "orders")
-    supplier_ds = dd.read_parquet(dataset_path + "supplier")
+    region_ds = dd.read_parquet(dataset_path + "region", filesystem=fs)
+    nation_ds = dd.read_parquet(dataset_path + "nation", filesystem=fs)
+    customer_ds = dd.read_parquet(dataset_path + "customer", filesystem=fs)
+    line_item_ds = dd.read_parquet(dataset_path + "lineitem", filesystem=fs)
+    orders_ds = dd.read_parquet(dataset_path + "orders", filesystem=fs)
+    supplier_ds = dd.read_parquet(dataset_path + "supplier", filesystem=fs)
 
     rsel = region_ds.r_name == "ASIA"
     osel = (orders_ds.o_orderdate >= date1) & (orders_ds.o_orderdate < date2)
@@ -185,12 +185,12 @@ def test_query_5(client, dataset_path):
     gb.reset_index().sort_values("revenue", ascending=False).compute()
 
 
-def test_query_6(client, dataset_path):
+def test_query_6(client, dataset_path, fs):
     date1 = datetime.strptime("1994-01-01", "%Y-%m-%d")
     date2 = datetime.strptime("1995-01-01", "%Y-%m-%d")
     var3 = 24
 
-    line_item_ds = dd.read_parquet(dataset_path + "lineitem")
+    line_item_ds = dd.read_parquet(dataset_path + "lineitem", filesystem=fs)
 
     sel = (
         (line_item_ds.l_shipdate >= date1)
@@ -204,15 +204,15 @@ def test_query_6(client, dataset_path):
     (flineitem.l_extendedprice * flineitem.l_discount).sum().compute()
 
 
-def test_query_7(client, dataset_path):
+def test_query_7(client, dataset_path, fs):
     var1 = datetime.strptime("1995-01-01", "%Y-%m-%d")
     var2 = datetime.strptime("1997-01-01", "%Y-%m-%d")
 
-    nation_ds = dd.read_parquet(dataset_path + "nation")
-    customer_ds = dd.read_parquet(dataset_path + "customer")
-    line_item_ds = dd.read_parquet(dataset_path + "lineitem")
-    orders_ds = dd.read_parquet(dataset_path + "orders")
-    supplier_ds = dd.read_parquet(dataset_path + "supplier")
+    nation_ds = dd.read_parquet(dataset_path + "nation", filesystem=fs)
+    customer_ds = dd.read_parquet(dataset_path + "customer", filesystem=fs)
+    line_item_ds = dd.read_parquet(dataset_path + "lineitem", filesystem=fs)
+    orders_ds = dd.read_parquet(dataset_path + "orders", filesystem=fs)
+    supplier_ds = dd.read_parquet(dataset_path + "supplier", filesystem=fs)
 
     lineitem_filtered = line_item_ds[
         (line_item_ds["l_shipdate"] >= var1) & (line_item_ds["l_shipdate"] < var2)

--- a/tests/tpch/test_polars.py
+++ b/tests/tpch/test_polars.py
@@ -1,9 +1,13 @@
 from datetime import datetime
 
 import polars as pl
+from pyarrow.dataset import dataset
 
 
 def read_data(filename):
+    pyarrow_dataset = dataset(filename, format="parquet")
+    return pl.scan_pyarrow_dataset(pyarrow_dataset)
+
     if filename.startswith("s3://"):
         import boto3
 
@@ -12,8 +16,8 @@ def read_data(filename):
         return pl.scan_parquet(
             filename,
             storage_options={
-                "aws_access_key_id": credentials.secret_key,
-                "aws_secret_access_key": credentials.access_key,
+                "aws_access_key_id": credentials.access_key,
+                "aws_secret_access_key": credentials.secret_key,
                 "region": "us-east-2",
             },
         )

--- a/tests/tpch/test_polars.py
+++ b/tests/tpch/test_polars.py
@@ -1,12 +1,24 @@
 from datetime import datetime
 
 import polars as pl
-from pyarrow.dataset import dataset
 
 
 def read_data(filename):
-    pyarrow_dataset = dataset(filename, format="parquet")
-    return pl.scan_pyarrow_dataset(pyarrow_dataset)
+    if filename.startswith("s3://"):
+        import boto3
+
+        session = boto3.session.Session()
+        credentials = session.get_credentials()
+        return pl.scan_parquet(
+            filename,
+            storage_options={
+                "aws_access_key_id": credentials.secret_key,
+                "aws_secret_access_key": credentials.access_key,
+                "region": "us-east-2",
+            },
+        )
+    else:
+        return pl.scan_parquet(filename + "/*")
 
 
 def test_query_1(run, restart, dataset_path):

--- a/tests/tpch/visualize.ipynb
+++ b/tests/tpch/visualize.ipynb
@@ -18,26 +18,33 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb350401-c096-4ccd-a214-b8ca72ec05c7",
+   "id": "c7ec3d43-3a70-4666-9552-04d82ac42a31",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ibis\n",
-    "ibis.options.interactive = True\n",
-    "con = ibis.sqlite.connect(\"../../benchmark.db\")\n",
-    "t = con.table(\"test_run\")\n",
-    "t"
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.read_sql_table(table_name=\"test_run\", con=\"sqlite:///../../benchmark.db\")\n",
+    "\n",
+    "df = df[(df.call_outcome == \"passed\") & (df.path.str.startswith(\"tpch/\")) & df.cluster_name]\n",
+    "df = df[[\"path\", \"name\", \"duration\", \"start\", \"cluster_name\"]]\n",
+    "\n",
+    "df[\"library\"] = df.path.map(lambda path: path.split(\"_\")[-1].split(\".\")[0])\n",
+    "df[\"query\"] = df.name.map(lambda name: int(name.split(\"_\")[-1]))\n",
+    "df[\"name\"] = df.cluster_name.map(lambda name: name.split(\"-\", 3)[-1])\n",
+    "df[\"scale\"] = df.cluster_name.map(lambda name: int(name.split(\"-\")[2]))\n",
+    "del df[\"path\"]\n",
+    "del df[\"cluster_name\"]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f7ba118-bdf0-4d45-8d5e-d1dea8e700ce",
+   "id": "31fbdc8a-c782-4000-9e23-5488b4d04d14",
    "metadata": {},
    "outputs": [],
    "source": [
-    "tt = t[(t.call_outcome == \"passed\") & (t.path.startswith(\"tpch/\"))]\n",
-    "tt[[\"path\", \"name\", \"duration\", \"start\"]]"
+    "df"
    ]
   },
   {
@@ -47,12 +54,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = tt[[\"path\", \"name\", \"duration\", \"start\"]].to_pandas()\n",
-    "\n",
-    "df[\"library\"] = df.path.map(lambda path: path.split(\"_\")[-1].split(\".\")[0])\n",
-    "df[\"query\"] = df.name.map(lambda name: int(name.split(\"_\")[-1]))\n",
-    "del df[\"path\"]\n",
-    "del df[\"name\"]\n",
     "df = df.sort_values([\"query\", \"library\"])\n",
     "\n",
     "def recent(df):\n",
@@ -66,28 +67,29 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9742acfa-2cf2-4503-ad79-0f3869112e68",
+   "id": "34830787-2364-4541-8cf8-8adffbde9148",
    "metadata": {},
    "outputs": [],
    "source": [
     "import altair as alt\n",
     "\n",
-    "alt.Chart(df).mark_bar().encode(\n",
+    "chart = alt.Chart(df).mark_bar().encode(\n",
     "    x=\"query:N\",\n",
     "    y=\"duration:Q\",\n",
     "    xOffset=\"library:N\",\n",
-    "    color=\"library:N\",\n",
-    "    tooltip=[\"library\", \"duration\"],\n",
-    ")"
+    "    color=alt.Color('library').scale(\n",
+    "        domain=[\"dask\", \"duckdb\", \"polars\", \"pyspark\"], \n",
+    "        range=[\"#5677a4\", \"#e68b39\", \"#d4605b\", \"green\"],\n",
+    "    ),\n",
+    "    tooltip=[\"library\", \"duration\"]\n",
+    ").properties(\n",
+    "    title=f\"TPC-H -- scale:{df.scale.iloc[0]} name:{df.name.iloc[0]}\"\n",
+    ").configure_title(\n",
+    "    fontSize=20,\n",
+    "\n",
+    ")\n",
+    "chart"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "34830787-2364-4541-8cf8-8adffbde9148",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This does a few things:

1.  Generate performance reports for every query if you add the `--performance-report` flag
2. Generate altair comparison charts
3. Change the infrastructure size up and down based on scale
4. Use Arrow filesystem (although I'm not sure how big a deal this is yet)
5. Improve charts to use consistent coloring, and drop ibis for pandas