### PR TITLE
Only test certain modules

### DIFF
--- a/ci/scripts/run_tests.sh
+++ b/ci/scripts/run_tests.sh
@@ -10,4 +10,4 @@ then
   EXTRA_OPTIONS="$EXTRA_OPTIONS --benchmark"
 fi
 
-python -m pytest $EXTRA_OPTIONS $@
+python -m pytest $EXTRA_OPTIONS $@ tests/{benchmarks,stability,workflows,tpch/test_dask.py}


### PR DESCRIPTION
Others like tpch/{spark,polars,duckdb} don't benefit from being regularly tested or like runtime, we don't care about.

Originally I was going to add a `pytest.mark.skip` but then I realized that that would make it hard to explicitly run certain tests.  I think that instead we want to make CI more specific about what it cares about.