### PR TITLE
Align TPC-H benchmarks better with their definition

### DIFF
--- a/tests/tpch/test_dask.py
+++ b/tests/tpch/test_dask.py
@@ -33,7 +33,7 @@ def test_query_1(client, dataset_path, fs):
             "avg_qty": "mean",
             "avg_price": "mean",
             "avg_disc": "mean",
-            "count_order": "count",
+            "count_order": "size",
         }
     )
 
@@ -149,7 +149,7 @@ def test_query_4(client, dataset_path, fs):
     ).drop_duplicates(subset=["o_orderkey"])
     result_df = (
         jn.groupby("o_orderpriority")["o_orderkey"]
-        .count()
+        .size()
         .reset_index()
         .sort_values(["o_orderpriority"])
     )


### PR DESCRIPTION
Count is the wrong function for these operations.

According to the spec, we want to get the length of every group. Count does count the rows in every group, but it ignores missing values. The results are the same because the column that we apply count to doesn't have missing values, but this requires knowledge of the data which is not in scope for TPC-H. The thing we actually want is size, which returns the size of every group irrespective of missing values