### PR TITLE
Add timeout to wait_for_workers

### DIFF
--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -44,7 +44,7 @@ def parquet_client(parquet_cluster, cluster_kwargs, upload_cluster_dump, benchma
     n_workers = cluster_kwargs["parquet_cluster"]["n_workers"]
     with distributed.Client(parquet_cluster) as client:
         parquet_cluster.scale(n_workers)
-        client.wait_for_workers(n_workers)
+        client.wait_for_workers(n_workers, timeout=600)
         client.restart()
         with upload_cluster_dump(client), benchmark_all(client):
             yield client

--- a/tests/benchmarks/test_spill.py
+++ b/tests/benchmarks/test_spill.py
@@ -39,7 +39,7 @@ def spill_client(spill_cluster, cluster_kwargs, upload_cluster_dump, benchmark_a
     n_workers = cluster_kwargs["spill_cluster"]["n_workers"]
     with Client(spill_cluster) as client:
         spill_cluster.scale(n_workers)
-        client.wait_for_workers(n_workers)
+        client.wait_for_workers(n_workers, timeout=600)
         client.restart()
         with upload_cluster_dump(client), benchmark_all(client):
             yield client

--- a/tests/benchmarks/test_work_stealing.py
+++ b/tests/benchmarks/test_work_stealing.py
@@ -42,7 +42,7 @@ def test_work_stealing_on_scaling_up(
     ) as cluster:
         with Client(cluster) as client:
             # FIXME https://github.com/coiled/platform/issues/103
-            client.wait_for_workers(1)
+            client.wait_for_workers(1, timeout=300)
             with upload_cluster_dump(client), benchmark_all(client):
                 # Slow task.
                 def func1(chunk):
@@ -104,7 +104,7 @@ def test_work_stealing_on_straggling_worker(
     ) as cluster:
         with Client(cluster) as client:
             # FIXME https://github.com/coiled/platform/issues/103
-            client.wait_for_workers(kwargs["n_workers"])
+            client.wait_for_workers(kwargs["n_workers"], timeout=600)
             with upload_cluster_dump(client), benchmark_all(client):
 
                 def clog():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -521,7 +521,7 @@ def small_client(
         log_on_scheduler(client, "Starting client setup of %s", test_label)
         client.restart()
         small_cluster.scale(n_workers)
-        client.wait_for_workers(n_workers)
+        client.wait_for_workers(n_workers, timeout=600)
 
         with upload_cluster_dump(client):
             log_on_scheduler(client, "Finished client setup of %s", test_label)


### PR DESCRIPTION
Lately we've frequently encountered stuck clusters on
```python
cluster.scale(n)
await client.wait_for_workers(n)
```
When that happens, reduce the timeout from 1 hour to 10 minutes.