### PR TITLE
skip test_read_spark_generated_data

### DIFF
--- a/tests/benchmarks/test_parquet.py
+++ b/tests/benchmarks/test_parquet.py
@@ -50,7 +50,7 @@ def parquet_client(parquet_cluster, cluster_kwargs, upload_cluster_dump, benchma
             yield client
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     HAS_PYARROW12,
     reason="50x slower than PyArrow 11; https://github.com/coiled/benchmarks/issues/998",
 )


### PR DESCRIPTION
- xref #998

Not only this test is exceptionally slow, but it also causes the next test to time out on setup, waiting for dead workers.