### PR TITLE
A more intuitive design for including/excluding tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,26 +96,29 @@ jobs:
           echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
           mamba env export | grep -E -v '^prefix:.*$'
 
-      - name: Determine if workflows should be run
+      - name: Disable workflows on most PRs
         # Run workflows on PRs with `workflows` label and nightly cron job
         if: |
-          github.event_name == 'schedule'
-          || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'workflows'))
+          github.event_name != 'schedule'
+          && !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'workflows'))
         run: |
-          # Put EXTRA_OPTIONS into $GITHUB_ENV so it can be used in subsequent workflow steps
-          export EXTRA_OPTIONS="--run-workflows"
-          echo $EXTRA_OPTIONS
-          echo EXTRA_OPTIONS=$EXTRA_OPTIONS >> $GITHUB_ENV
+          echo PYTEST_MARKERS=" and not workflows" >> $GITHUB_ENV
 
-      - name: Determine if all TPC-H benchmarks should be run
+      - name: Disable non-Dask TPCH benchmarks on most PRs
         if: |
-          github.event_name == 'schedule'
-          || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'tpch'))
+          github.event_name != 'schedule'
+          && !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'tpch'))
         run: |
-          # Put EXTRA_OPTIONS into $GITHUB_ENV so it can be used in subsequent workflow steps
-          export EXTRA_OPTIONS="${EXTRA_OPTIONS} --tpch-non-dask"
-          echo $EXTRA_OPTIONS
-          echo EXTRA_OPTIONS=$EXTRA_OPTIONS >> $GITHUB_ENV
+          echo PYTEST_MARKERS="${{ env.PYTEST_MARKERS }} and not tpch_nondask" >> $GITHUB_ENV
+
+      - name: Finalize PYTEST_MARKERS
+        run: |
+          if [ -n "$PYTEST_MARKERS" ]; then
+            PYTEST_MARKERS=${PYTEST_MARKERS# and }
+            PYTEST_MARKERS="-m '${PYTEST_MARKERS}'"
+            echo PYTEST_MARKERS=${PYTEST_MARKERS}
+            echo PYTEST_MARKERS=${PYTEST_MARKERS} >> $GITHUB_ENV
+          fi
 
       - name: Run Coiled Runtime Tests
         env:
@@ -131,7 +134,8 @@ jobs:
           COILED_RUNTIME_VERSION: ${{ matrix.runtime-version }}
           DB_NAME: ${{ matrix.os }}-py${{ matrix.python-version }}.db
           CLUSTER_DUMP: always
-        run: pytest --benchmark -n 4 --dist loadscope ${{ env.EXTRA_OPTIONS }} ${{ matrix.pytest_args }}
+        run: |
+          pytest --benchmark -n 4 --dist loadscope ${{ env.PYTEST_MARKERS }} ${{ matrix.pytest_args }}
 
       - name: Dump coiled.Cluster kwargs
         run: cat cluster_kwargs.merged.yaml || true

--- a/AB_environments/config.yaml
+++ b/AB_environments/config.yaml
@@ -16,6 +16,7 @@ targets:
   - tests/benchmarks
   # - tests/runtime
   # - tests/stability
+  # - tests/tpch/test_dask.py
   # - tests/benchmarks/test_futures.py
   # - tests/benchmarks/test_array.py::test_basic_sum
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,12 @@ profile = black
 [tool:pytest]
 addopts = -v -rsxfE --durations=0 --color=yes --strict-markers --strict-config --dist loadscope
 markers =
-    stability: marks stability tests
+    stability: stability tests; not meant to measure performance
+    workflows: workflow tests; expensive to run. Disabled in PRs.
     shuffle_p2p: p2p shuffle engine
     shuffle_tasks: legacy tasks-based shuffle engine
+    tpch_dask: dask implementation of the TPCH tests suite
+    tpch_nondask: competitors' (not dask) implementation of the TPCH test suite
 
 # pytest-timeout settings
 # 'thread' kills off the whole test suite. 'signal' only kills the offending test.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,12 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_sessionfinish(session, exitstatus):
+    # https://github.com/pytest-dev/pytest/issues/2393
+    if exitstatus == 5:  # All tests excluded by markers
+        session.exitstatus = 0
+
+
 def _is_child_dir(path: str | Path, parent: str | Path) -> bool:
     _parent = Path(parent).absolute()
     _path = Path(path).absolute()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,37 +58,6 @@ def pytest_addoption(parser):
     parser.addoption(
         "--benchmark", action="store_true", help="Collect benchmarking data for tests"
     )
-    parser.addoption("--run-workflows", action="store_true", help="Run workflow tests")
-    parser.addoption(
-        "--tpch-non-dask",
-        action="store_true",
-        help="Run all (DuckDB / Polars / PySpark) TPCH benchmarks",
-    )
-
-
-def pytest_collection_modifyitems(config, items):
-    # Skip workflows unless --run-workflows is set OR user explicitly included some path
-    # which includes the workflows ie pytest tests/workflows/
-    skip_workflows = pytest.mark.skip(reason="need --run-workflows option to run")
-    workflows = TEST_DIR / "workflows"
-    if not config.getoption("--run-workflows") and not any(
-        _is_child_dir(path, workflows) for path in config.option.file_or_dir
-    ):
-        for item in items:
-            if workflows in item.path.parents:
-                item.add_marker(skip_workflows)
-
-    # Skip non Dask TPC-H tests unless --tpch-non-dask is set OR user explicitly
-    # included some path which inclues the `tpch` path. ie pytest tests/tpch/
-    skip_benchmarks = pytest.mark.skip(reason="need --tpch-non-dask option to run")
-    tpch = TEST_DIR / "tpch"
-    tpch_dask = tpch / "test_dask.py"
-    if not config.getoption("--tpch-non-dask") and not any(
-        _is_child_dir(path, tpch) for path in config.option.file_or_dir
-    ):
-        for item in items:
-            if tpch in item.path.parents and tpch_dask != item.path:
-                item.add_marker(skip_benchmarks)
 
 
 def _is_child_dir(path: str | Path, parent: str | Path) -> bool:

--- a/tests/runtime/test_xgboost.py
+++ b/tests/runtime/test_xgboost.py
@@ -1,14 +1,11 @@
 import dask.dataframe as dd
 import pytest
 
-# `coiled-runtime=0.0.4` don't contain `xgboost`
+dask_ml = pytest.importorskip("dask_ml")
 xgb = pytest.importorskip("xgboost")
 
 
 def test_xgboost_distributed_training(small_client):
-    # `coiled-runtime=0.0.4` don't contain `dask_ml`
-    dask_ml = pytest.importorskip("dask_ml")
-
     ddf = dd.read_parquet(
         "s3://coiled-datasets/synthetic-data/synth-reg-104GB.parquet",
         storage_options={"anon": True},

--- a/tests/stability/test_array.py
+++ b/tests/stability/test_array.py
@@ -5,22 +5,14 @@ import pytest
 
 from ..utils_test import cluster_memory, scaled_array_shape, wait
 
-# Don't use `scipy = pytest.importorskip("scipy") inside the test.
-# Since there's only one test in this module, the cluster would be started needlessly
-# if scipy is missing.
-try:
-    import scipy  # noqa: F401
+pytestmark = pytest.mark.stability
 
-    has_scipy = True
-except ImportError:
-    has_scipy = False
+pytest.importorskip("scipy")
 
 
-@pytest.mark.stability
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="scaled_array_shape fails on windows"
 )
-@pytest.mark.skipif(not has_scipy, reason="requires scipy")
 def test_ols(small_client):
     chunksize = int(1e6)
     memory = cluster_memory(small_client)

--- a/tests/stability/test_deadlock.py
+++ b/tests/stability/test_deadlock.py
@@ -7,6 +7,8 @@ from coiled import Cluster
 from distributed import Client, wait
 from packaging.version import Version
 
+pytestmark = pytest.mark.stability
+
 
 @pytest.mark.skipif(
     Version(distributed.__version__) < Version("2022.4.2"),

--- a/tests/tpch/README.md
+++ b/tests/tpch/README.md
@@ -24,11 +24,11 @@ mamba env update -f ci/environment-test.yml
 mamba install grpcio grpcio-status protobuf -y  # if you want Spark
 ```
 
-Run Single Benchmark
---------------------
+Run Dask Benchmarks
+-------------------
 
 ```
-py.test --benchmark tests/tpch/test_dask.py
+pytest --benchmark tests/tpch/test_dask.py
 ```
 
 Configure

--- a/tests/tpch/test_dask.py
+++ b/tests/tpch/test_dask.py
@@ -1,6 +1,10 @@
 from datetime import datetime
 
-import dask_expr as dd
+import pytest
+
+pytestmark = pytest.mark.tpch_dask
+
+dd = pytest.importorskip("dask_expr")
 
 
 def test_query_1(client, dataset_path, fs):

--- a/tests/tpch/test_duckdb.py
+++ b/tests/tpch/test_duckdb.py
@@ -1,6 +1,8 @@
 import botocore.session
 import pytest
 
+pytestmark = pytest.mark.tpch_nondask
+
 duckdb = pytest.importorskip("duckdb")
 
 

--- a/tests/tpch/test_polars.py
+++ b/tests/tpch/test_polars.py
@@ -4,8 +4,10 @@ import pytest
 
 pytestmark = pytest.mark.tpch_nondask
 
-dataset = pytest.importorskip("pyarrow.dataset")
 pl = pytest.importorskip("polars")
+pytest.importorskip("pyarrow")
+
+from pyarrow.dataset import dataset  # noqa: E402
 
 
 def read_data(filename):

--- a/tests/tpch/test_polars.py
+++ b/tests/tpch/test_polars.py
@@ -1,8 +1,10 @@
 from datetime import datetime
 
 import pytest
-from pyarrow.dataset import dataset
 
+pytestmark = pytest.mark.tpch_nondask
+
+dataset = pytest.importorskip("pyarrow.dataset")
 pl = pytest.importorskip("polars")
 
 

--- a/tests/tpch/test_pyspark.py
+++ b/tests/tpch/test_pyspark.py
@@ -2,6 +2,8 @@ import re
 
 import pytest
 
+pytestmark = pytest.mark.tpch_nondask
+
 pytest.importorskip("coiled.spark")
 
 

--- a/tests/tpch/visualize.ipynb
+++ b/tests/tpch/visualize.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "```\n",
     "rm benchmark.db\n",
-    "pytest --benchmark tests/benchmarks/tpch --tpch-non-dask\n",
+    "pytest --benchmark tests/tpch\n",
     "```"
    ]
   },

--- a/tests/workflows/test_embarrassingly_parallel.py
+++ b/tests/workflows/test_embarrassingly_parallel.py
@@ -5,6 +5,8 @@ import pandas as pd
 import pytest
 from dask.distributed import wait
 
+pytestmark = pytest.mark.workflows
+
 
 @pytest.mark.client("embarrassingly_parallel")
 def test_embarassingly_parallel(client, s3_factory):

--- a/tests/workflows/test_from_csv_to_parquet.py
+++ b/tests/workflows/test_from_csv_to_parquet.py
@@ -3,6 +3,9 @@ from collections import OrderedDict
 import dask.dataframe as dd
 import pytest
 
+pytestmark = pytest.mark.workflows
+
+
 SCHEMA = OrderedDict(
     [
         ("GlobalEventID", "Int64"),

--- a/tests/workflows/test_pytorch_optuna.py
+++ b/tests/workflows/test_pytorch_optuna.py
@@ -8,6 +8,8 @@ from dask.distributed import Lock, PipInstall, get_worker
 
 from ..utils_test import wait
 
+pytestmark = pytest.mark.workflows
+
 optuna = pytest.importorskip("optuna")
 
 

--- a/tests/workflows/test_snowflake.py
+++ b/tests/workflows/test_snowflake.py
@@ -7,7 +7,8 @@ import pytest
 
 pytestmark = pytest.mark.workflows
 
-pytest.importorskip("dask_snowflake", reason="Requires dask-snowflake")
+pytest.importorskip("dask_snowflake")
+pytest.importorskip("sqlalchemy")
 
 from dask_snowflake import read_snowflake, to_snowflake  # noqa: E402
 from snowflake.sqlalchemy import URL  # noqa: E402

--- a/tests/workflows/test_snowflake.py
+++ b/tests/workflows/test_snowflake.py
@@ -5,6 +5,8 @@ import dask.dataframe as dd
 import pandas as pd
 import pytest
 
+pytestmark = pytest.mark.workflows
+
 pytest.importorskip("dask_snowflake", reason="Requires dask-snowflake")
 
 from dask_snowflake import read_snowflake, to_snowflake  # noqa: E402

--- a/tests/workflows/test_uber_lyft.py
+++ b/tests/workflows/test_uber_lyft.py
@@ -1,6 +1,8 @@
 import dask.dataframe as dd
 import pytest
 
+pytestmark = pytest.mark.workflows
+
 
 @pytest.mark.client("uber_lyft")
 def test_exploratory_analysis(client):

--- a/tests/workflows/test_xgboost_optuna.py
+++ b/tests/workflows/test_xgboost_optuna.py
@@ -1,6 +1,8 @@
 import pytest
 from dask.distributed import wait
 
+pytestmark = pytest.mark.workflows
+
 optuna = pytest.importorskip("optuna")
 xgb = pytest.importorskip("xgboost")
 pytest.importorskip("sklearn")


### PR DESCRIPTION
Simplify the design for including/excluding tests:

- Manually running `pytest tests`, `pytest tests/tpch`, or `pytest tests/workflow` now runs everything, as expected
- It is now possible to run non-dask TPCH tests and/or workflows in A/B
- When tests are run by default doesn't change. What changes is how easy it is to go against it:
  - everything outside of benchmarks is still excluded by default in A/B
  - workflows and non-dask TPCH tests still run exclusively overnight, unless explicitly requested through PR tags

Out of scope:
- reduce frequency of non-TPCH tests to weekly