### PR TITLE
Add support for RAPIDS in TPC-H benchmarks

### DIFF
--- a/ci/environment-rapids.yml
+++ b/ci/environment-rapids.yml
@@ -1,0 +1,11 @@
+# This is an addition to ci/environment.yml.
+# Add cudf and downgrade some pinned dependencies.
+channels:
+  - rapidsai-nightly
+  - conda-forge
+  - nvidia
+dependencies:
+  - dask-cudf =24.02
+  - dask-cuda =24.02
+  - pandas ==1.5.3  # pinned by cudf
+  - pynvml ==11.4.1  # pinned by dask-cuda

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -8,14 +8,13 @@ dependencies:
 # - AB_environments/AB_sample.conda.yaml
 ########################################################
 
-  - python >=3.9
+  - python >=3.9,<3.11
   - pip
   - coiled >=0.2.54
   - numpy ==1.24.4
   - pandas ==2.1.1
   - dask ==2023.10.1
   - distributed ==2023.10.1
-  - dask-expr ==0.1.11
   - dask-labextension ==7.0.0
   - dask-ml ==2023.3.24
   - fsspec ==2023.9.1

--- a/tests/tpch/conftest.py
+++ b/tests/tpch/conftest.py
@@ -208,7 +208,9 @@ def cluster(
         else:
             from dask_cuda import LocalCUDACluster
 
-            with dask.config.set({"dataframe.backend": "cudf", "dataframe.shuffle.method": "tasks"}):
+            with dask.config.set(
+                {"dataframe.backend": "cudf", "dataframe.shuffle.method": "tasks"}
+            ):
                 with LocalCUDACluster() as cluster:
                     yield cluster
     else:


### PR DESCRIPTION
Right now this is mostly updating @rjzamora's work in [this branch](https://github.com/rjzamora/coiled-benchmarks/tree/tpch-rapids), but ideally would like to expand this to eventually add cloud support for RAPIDS via Coiled