### PR TITLE
Move aside TPCH non-dask dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,10 @@ jobs:
             python-version: "3.9"
             os: ubuntu-latest
             extra-env: ci/environment-snowflake.yml
+          - pytest_args: tests/tpch -m tpch_nondask
+            python-version: "3.9"
+            os: ubuntu-latest
+            extra-env: ci/environment-tpch-nondask.yml
 
     steps:
       - name: Checkout

--- a/AB_environments/AB_baseline.conda.yaml
+++ b/AB_environments/AB_baseline.conda.yaml
@@ -43,13 +43,6 @@ dependencies:
   - bokeh ==3.3.2
   - gilknocker ==0.4.1
   - openssl >1.1.0g
-  - pyspark ==3.4.1  # FIXME https://github.com/coiled/benchmarks/issues/1221
-  - openjdk ~=11.0  # Do not upgrade
-  - grpcio ==1.59.3
-  - grpcio-status ==1.57.0  # FIXME https://github.com/coiled/benchmarks/issues/1221
-  - protobuf ==4.24.4
-  - python-duckdb ==0.9.2
-  - polars ==0.19.19
   # End copy-paste
 
   - pip:

--- a/AB_environments/AB_sample.conda.yaml
+++ b/AB_environments/AB_sample.conda.yaml
@@ -48,13 +48,6 @@ dependencies:
   - bokeh ==3.3.2
   - gilknocker ==0.4.1
   - openssl >1.1.0g
-  - pyspark ==3.4.1  # FIXME https://github.com/coiled/benchmarks/issues/1221
-  - openjdk ~=11.0  # Do not upgrade
-  - grpcio ==1.59.3
-  - grpcio-status ==1.57.0  # FIXME https://github.com/coiled/benchmarks/issues/1221
-  - protobuf ==4.24.4
-  - python-duckdb ==0.9.2
-  - polars ==0.19.19
   # End copy-paste
 
   - pip:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Set of Dask benchmarks run daily at scale in Coiled Clusters.
 
 The `coiled benchmarks` test suite can be run locally with the following steps:
 
-1. Ensure your local machine is authenticated to use the `dask-engineering` Coiled
+1. Ensure your local machine is authenticated to use the `dask-benchmarks` Coiled
    account and the Coiled Dask Engineering AWS S3 account.
 2. Create a new Python environment with
    `mamba env create -n test-env -f ci/environment.yml`. You could alternatively use
@@ -18,9 +18,17 @@ The `coiled benchmarks` test suite can be run locally with the following steps:
    This test suite is configured to run Coiled's `package_sync` feature, so your local
    environment will be copied to the cluster.
 3. Activate the environment with `conda activate test-env`
-4. Upgrade dask to the git tip with `mamba env update -f ci/environment-git-tip.yml`
-5. Add test-specific packages with `mamba env update -f ci/environment-test.yml`
-6. Run tests with `python -m pytest tests`
+4. Some tests require additional dependencies:
+   - For snowflake: `mamba env update -f ci/environment-snowflake.yml`  
+   - For non-dask TPCH: `mamba env update -f ci/environment-tpch-nondask.yml`
+
+    Look at `ci/environment-*.yml` for more options.
+5. Upgrade dask to the git tip with `mamba env update -f ci/environment-git-tip.yml`
+6. Add test-specific packages with `mamba env update -f ci/environment-test.yml`
+7. Run tests with `python -m pytest tests`.
+   You may consider running instead individual tests or categories of tests; e.g.
+   `python -m pytest tests -m shuffle_p2p`.
+   Look at `setup.cfg` for all available test markers.
 
 Additionally, tests are automatically run on pull requests to this repository.
 See the section below on creating pull requests.
@@ -127,7 +135,8 @@ and one with a `dask` repository with which to drive bisecting.
 
 #### Create your software environment
 
-You should create a software environment which can run this test suite, but with an editable install of `dask`.
+You should create a software environment which can run this test suite, but with an
+editable install of `dask`.
 You can do this in any of a number of ways, but one approach coule be
 ```bash
 mamba env create -n test-env --file ci/environment.yml  # Create a test environment
@@ -138,7 +147,10 @@ mamba env update --file ci/environment-test.yml
 
 #### Start bisecting
 
-Let's say the current `HEAD` of `dask` is known to be bad, and `$REF` is known to be good. If you are looking at an upstream run where you have access to the static page, you can check the dates reported for each run and do a `git log` with the corresponding dates to get a list of commits to use in the bisecting process.
+Let's say the current `HEAD` of `dask` is known to be bad, and `$REF` is known to be
+good. If you are looking at an upstream run where you have access to the static page,
+you can check the dates reported for each run and do a `git log` with the corresponding
+dates to get a list of commits to use in the bisecting process.
 
 `git log --since='2022-08-15 14:15' --until='2022-08-18 14:15' --pretty=oneline`
 In the terminal opened to your dask repository you can initialize a bisect workflow with
@@ -152,7 +164,8 @@ git bisect good $REF
 
 #### Test for regressions
 
-Now that your editable install is bisecting, run a test or subset of tests which demonstrate the regression in your `coiled-runtime` terminal.
+Now that your editable install is bisecting, run a test or subset of tests which
+demonstrate the regression in your `coiled-runtime` terminal.
 Presume that `tests/benchmarks/test_parquet.py::test_write_wide_data` is such a test:
 
 ```bash
@@ -194,11 +207,12 @@ It's possible to run the Coiled Runtime benchmarks for A/B comparisons.
 
 ## Contribute
 
-This repository uses GitHub Actions secrets for managing authentication tokens used
-to access resources like Coiled clusters, S3 buckets, etc. However, because GitHub Actions [doesn't
-grant access to secrets for forked repositories](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow),
-**please submit pull requests directly from the `coiled/benchmarks` repository,
-not a personal fork**.
+This repository uses GitHub Actions secrets for managing authentication tokens used to
+access resources like Coiled clusters, S3 buckets, etc. However, because GitHub Actions
+[doesn't grant access to secrets for forked
+repositories](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow),
+**please submit pull requests directly from the `coiled/benchmarks` repository, not a
+personal fork**.
 
 
 ## License

--- a/ci/environment-tpch-nondask.yml
+++ b/ci/environment-tpch-nondask.yml
@@ -1,0 +1,16 @@
+# This is an addition to ci/environment.yml.
+# Add dependencies exclusively needed to run TPCH tests on dask competitors.
+channels:
+  - conda-forge
+dependencies:
+  # PySpark
+  # See https://spark.apache.org/docs/latest/api/python/getting_started/install.html#dependencies
+  - pyspark ==3.4.1 # FIXME https://github.com/coiled/benchmarks/issues/1221
+  - openjdk ~=11.0  # Do not upgrade
+  - grpcio ==1.59.3
+  - grpcio-status ==1.57.0 # FIXME https://github.com/coiled/benchmarks/issues/1221
+  - protobuf ==4.24.4
+
+  # Other TPCH tests
+  - python-duckdb ==0.9.2
+  - polars ==0.19.19

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -45,13 +45,6 @@ dependencies:
   - bokeh ==3.3.2
   - gilknocker ==0.4.1
   - openssl >1.1.0g
-  - pyspark ==3.4.1  # FIXME https://github.com/coiled/benchmarks/issues/1221
-  - openjdk ~=11.0  # Do not upgrade
-  - grpcio ==1.59.3
-  - grpcio-status ==1.57.0  # FIXME https://github.com/coiled/benchmarks/issues/1221
-  - protobuf ==4.24.4
-  - python-duckdb ==0.9.2
-  - polars ==0.19.19
 
 ########################################################
 # PLEASE READ:


### PR DESCRIPTION
Non-dask TPCH tests have substantial dependencies that can be very fiddly, and are typically excluded from PRs and A/B tests. Move them out of the way in order to slim down the general environment file and possibly for faster deployment (a crude spot observation shows cluster startup time has gone down from 300s to 230s).

- Blocked by and incorporates #1220