### PR TITLE
Support whitespace in A/B targets

### DIFF
--- a/ci/scripts/discover_ab_environments.py
+++ b/ci/scripts/discover_ab_environments.py
@@ -59,16 +59,20 @@ def build_json() -> JSONOutput:
     if cfg["test_null_hypothesis"]:
         runtimes += ["AB_null_hypothesis"]
 
-    n = cfg["max_parallel"]["pytest_workers_per_job"]
-    xdist_args = f"-n {n} --dist loadscope " if n > 1 else ""
-    markers_args = f" -m '{cfg['markers']}' " if cfg["markers"] else ""
+    pytest_args = []
+    if (n := cfg["max_parallel"]["pytest_workers_per_job"]) > 1:
+        pytest_args.append(f"-n {n} --dist loadscope")
+    if cfg["markers"]:
+        pytest_args.append(f"-m '{cfg['markers']}'")
+    for target in cfg["targets"]:
+        pytest_args.append(f"'{target}'")
 
     return {
         "run_AB": True,
         "repeat": list(range(1, cfg["repeat"] + 1)),
         "runtime": runtimes,
         "max_parallel": cfg["max_parallel"]["ci_jobs"],
-        "pytest_args": [xdist_args + markers_args + " ".join(cfg["targets"])],
+        "pytest_args": [" ".join(pytest_args)],
         "h2o_datasets": [",".join(cfg["h2o_datasets"])],
     }
 


### PR DESCRIPTION
This PR allows, for example, to write in `AB_environments/config.yaml`:
```yaml
targets:
  - tests/benchmarks/test_rechunk.py::test_swap_axes[1-128 MiB-tasks]
  - tests/benchmarks/test_rechunk.py::test_swap_axes[1-128 MiB-p2p-disk]
  - tests/benchmarks/test_rechunk.py::test_tiles_to_rows[1-128 MiB-tasks]
  - tests/benchmarks/test_rechunk.py::test_tiles_to_rows[1-128 MiB-p2p-disk]
```
