### PR TITLE
xfail PyTorch Optuna workflow on TimeoutError

### DIFF
--- a/tests/workflows/test_pytorch_optuna.py
+++ b/tests/workflows/test_pytorch_optuna.py
@@ -14,6 +14,13 @@ pytestmark = pytest.mark.workflows
 optuna = pytest.importorskip("optuna")
 
 
+@pytest.mark.xfail(
+    raises=TimeoutError,
+    reason=(
+        "Occasionally fails to install/attach CUDA, "
+        "will then run on CPU and get a TimeoutError"
+    ),
+)
 @pytest.mark.client(
     "pytorch_optuna",
     worker_plugin=PipInstall(


### PR DESCRIPTION
Will close https://github.com/coiled/benchmarks/issues/1261

_"90% of the time, it works every time."_ :wink: 

Mostly works on CI, but occasionally fails because the model doesn't manage to detect/use CUDA. IMO I don't think it's worthwhile to devote much time debugging why this is the case. 