### PR TITLE
Limit execution of TPC-H non-Dask benchmarks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,10 +111,12 @@ jobs:
 
       - name: Disable non-Dask TPCH benchmarks on most PRs and on daily schedule (except Sundays)
         if: |
-          ${{ !(
-            contains(matrix.pytest_args, 'tpch_nondask')
-            || (github.event_name == 'schedule' || github.event.schedule == "1 0 * * 0")
-            || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'tpch'))
+          ${{ 
+            !contains(matrix.pytest_args, 'tpch_nondask')
+            || !(
+              (github.event_name == 'schedule' || github.event.schedule == "1 0 * * 0")
+              || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'tpch'))
+            )
           ) }}
         run: |
           echo PYTEST_MARKERS="${{ env.PYTEST_MARKERS }} and not tpch_nondask" >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,8 +112,9 @@ jobs:
       - name: Disable non-Dask TPCH benchmarks on most PRs and on daily schedule (except Sundays)
         if: |
           ${{ !(
-          (github.event_name == 'schedule' || github.event.schedule == "1 0 * * 0")
-          || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'workflows'))
+            contains(matrix.pytest_args, 'tpch_nondask')
+            || (github.event_name == 'schedule' || github.event.schedule == "1 0 * * 0")
+            || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'tpch'))
           ) }}
         run: |
           echo PYTEST_MARKERS="${{ env.PYTEST_MARKERS }} and not tpch_nondask" >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,8 @@ on:
   pull_request:
   schedule:
     # Runs "At 00:01" (see https://crontab.guru)
-    - cron: "1 0 * * *"
+    - cron: "1 0 * * 0" # every Sunday (relevant for non-Dask TPC-H benchmarks) 
+    - cron: "1 0 * * 1-6" # every day except Sunday
   workflow_dispatch:
 
 concurrency:
@@ -108,10 +109,12 @@ jobs:
         run: |
           echo PYTEST_MARKERS=" and not workflows" >> $GITHUB_ENV
 
-      - name: Disable non-Dask TPCH benchmarks on most PRs
+      - name: Disable non-Dask TPCH benchmarks on most PRs and on daily schedule (except Sundays)
         if: |
-          github.event_name != 'schedule'
-          && !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'tpch'))
+          ${{ !(
+          (github.event_name == 'schedule' || github.event.schedule == "1 0 * * 0")
+          || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'workflows'))
+          ) }}
         run: |
           echo PYTEST_MARKERS="${{ env.PYTEST_MARKERS }} and not tpch_nondask" >> $GITHUB_ENV
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9"]
-        pytest_args: [tests]
+        pytest_args: [tests --ignore=tests/tpch]
         extra-env: [""]
         include:
           # Run stability tests on the lowest and highest versions of Python only
@@ -61,7 +61,7 @@ jobs:
             python-version: "3.9"
             os: ubuntu-latest
             extra-env: ci/environment-snowflake.yml
-          - pytest_args: tests/tpch -m tpch_nondask
+          - pytest_args: tests/tpch
             python-version: "3.9"
             os: ubuntu-latest
             extra-env: ci/environment-tpch-nondask.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,7 +117,7 @@ jobs:
               (github.event_name == 'schedule' || github.event.schedule == '1 0 * * 0')
               || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'tpch'))
             )
-          ) }}
+          }}
         run: |
           echo PYTEST_MARKERS="${{ env.PYTEST_MARKERS }} and not tpch_nondask" >> $GITHUB_ENV
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,7 @@ jobs:
           ${{ 
             !contains(matrix.pytest_args, 'tpch_nondask')
             || !(
-              (github.event_name == 'schedule' || github.event.schedule == "1 0 * * 0")
+              (github.event_name == 'schedule' || github.event.schedule == '1 0 * * 0')
               || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'tpch'))
             )
           ) }}


### PR DESCRIPTION
We thought that the existing logic worked, but it turns out that we were just running Dask-based TPC-H queries once as part of  `Tests / tests` and then running _all_ TPC-H queries as part of the `Tests / tests/tpch -m tpch_nondask` run and discarding the results of the latter run due to #1332.