### PR TITLE
Fix CI failure

### DIFF
--- a/tests/tpch/conftest.py
+++ b/tests/tpch/conftest.py
@@ -36,6 +36,7 @@ def pytest_addoption(parser):
         default="",
         help="Name to use for run",
     )
+    parser.addoption("--plot", action="store_true", default=False, help="")
 
 
 @pytest.fixture(scope="session")
@@ -370,6 +371,11 @@ def make_chart(request, name, tmp_path_factory, local, scale):
     if not request.config.getoption("--benchmark"):
         # Won't create the sqlite DB, and thus won't be able
         # to read test run information
+        yield
+        return
+
+    if not request.config.getoption("--plot"):
+        # Don't generate the plot
         yield
         return
 

--- a/tests/tpch/generate_plot.py
+++ b/tests/tpch/generate_plot.py
@@ -10,7 +10,7 @@ def generate(outfile="chart.json", name=None, scale=None):
 
     df = df[
         (df.call_outcome == "passed")
-        & (df.path.str.startswith("tpch/"))
+        & (df.path.str.contains("^tpch/test_(?:dask|duckdb|polars|pyspark)"))
         & df.cluster_name
     ]
     df = df[["path", "name", "duration", "start", "cluster_name"]]


### PR DESCRIPTION
Fixes `ERROR tests/tpch/test_dask.py::test_query_22 - ValueError: invalid literal for int() with base 10: 'optimization[1]'`