### PR TITLE
TPC-H data generation script fixup

### DIFF
--- a/tests/tpch/generate_data.py
+++ b/tests/tpch/generate_data.py
@@ -295,7 +295,7 @@ def get_bucket_region(path: str):
 )
 @click.option(
     "--compression",
-    type=click.Choice(v.lower() for v in CompressionCodec.__members__),
+    type=click.Choice([v.upper() for v in CompressionCodec.__members__]),
     callback=lambda _c, _p, v: getattr(CompressionCodec, v.upper()),
     default=CompressionCodec.SNAPPY.value,
     help="Set compression codec",


### PR DESCRIPTION
I was getting errors running `python tests/tpch/generate_data.py --scale 1` locally (one from `click.Choice` not liking a generator as input, and another due to compression name uppercase/lowercase mismatch). This PR fixes things for me locally. 