### PR TITLE
[TPC-H] Adjust default cluster sizes

### DIFF
--- a/tests/tpch/conftest.py
+++ b/tests/tpch/conftest.py
@@ -147,7 +147,7 @@ def cluster_spec(scale):
     if scale == 10:
         return {
             "worker_vm_types": ["m6i.large"],
-            "n_workers": 16,
+            "n_workers": 8,
             **everywhere,
         }
     elif scale == 100:
@@ -158,15 +158,15 @@ def cluster_spec(scale):
         }
     elif scale == 1000:
         return {
-            "worker_vm_types": ["m6i.large"],
+            "worker_vm_types": ["m6i.xlarge"],
             "n_workers": 32,
             **everywhere,
         }
     elif scale == 10000:
         return {
-            "worker_vm_types": ["m6i.2xlarge"],
-            "n_workers": 64,
-            "worker_disk_size": 100,
+            "worker_vm_types": ["m6i.xlarge"],
+            "n_workers": 32,
+            "worker_disk_size": 200,
             **everywhere,
         }
 
@@ -294,7 +294,7 @@ def fs(local):
 def machine_spec(scale):
     if scale == 10:
         return {
-            "vm_type": "m6i.8xlarge",
+            "vm_type": "m6i.4xlarge",
         }
     elif scale == 100:
         return {
@@ -302,7 +302,7 @@ def machine_spec(scale):
         }
     elif scale == 1000:
         return {
-            "vm_type": "m6i.16xlarge",
+            "vm_type": "m6i.32xlarge",
         }
     elif scale == 10000:
         return {


### PR DESCRIPTION
Adjusts default cluster sizes following changes suggested in #1166. 

Changes:
**Scale 10**
* Reduced number of VMs by half from 16 to 8 machines. This is probably better as it felt opverprovisioned.
* Halfed single VM size from `m6i.8xlarge` (32 CPUs, 128 GiB RAM) to `m6i.4xlarge` (16 CPUs, 64 GiB RAM) to match.


**Scale 100**
_No changes_

**Scale 1000**
* Doubled VM size form `m6i.large` (2 CPUs, 8 GiB RAM) to `m6i.xlarge` (4 CPUs, 16 GiB RAM).
During our latest runs, we've noticed that the configuration for scale 1000 is not large enough and needs to be doubled. 
* Doubled single VM size from `m6i.16xlarge` (64 CPUs, 256 GiB RAM) to `m6i.32xlarge` (128 CPUs, 256 GiB RAM) to match.

**Scale 10000**
* Reduced number of VMs by half from 64 to 32 to match single VM size. 
_Note: We have not run this yet but this is the only way to keep CPU count constant as there's no larger `m6i` VM available for the single VM types._