### PR TITLE
Fix python-version argument for benchmarks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           condarc-file: ci/condarc
-          python_version: ${{ matrix.python_version }}
+          python-version: ${{ matrix.python_version }}
           environment-file: ci/environment.yml
 
       - name: Add extra packages to environment
@@ -174,7 +174,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python_version: "3.10"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: pip install alembic


### PR DESCRIPTION
Closes #1383 
Follow-up to https://github.com/coiled/benchmarks/pull/1349 which accidentally caused all tests to be run on Python 3.11. 

FWIW, we didn't lose data but accidentally ran tests on 3.11 and even generated dashboards for that: https://benchmarks.coiled.io/Python%203.11.html