### PR TITLE
Refactor TPC-H generation script - consolidate small table partitions

### DIFF
--- a/tests/tpch/generate_data.py
+++ b/tests/tpch/generate_data.py
@@ -66,8 +66,9 @@ def generate(
     if use_coiled:
         with coiled.Cluster(
             n_workers=10,
-            # workload is best with 1vCPU and ~3-4GiB memory
-            worker_vm_types=["m7a.medium", "m3.medium"],
+            # workload is best with 1vCPU and ~6-8GiB memory
+            worker_cpu=[1, 2],
+            worker_memory=["6GiB", "8GiB"],
             worker_options={"nthreads": 1},
             region=REGION,
         ) as cluster:


### PR DESCRIPTION
Will close #1386

It's made slightly more complex b/c duckdb doesn't support generating data for a single table. So we can keep things mostly the same but just not write out the partitions but collect and combine them at the end of the normal partition generation.

Also made some other adjustments small refactoring, including using a localcluster to generate the data locally to more closely replicate the behavior when using Coiled. Plus it goes faster generating larger scales. :) 