### PR TITLE
[TPC-H] Adopt Spark join ordering in query 18

### DIFF
--- a/tests/tpch/dask_queries.py
+++ b/tests/tpch/dask_queries.py
@@ -945,7 +945,6 @@ def query_18(dataset_path, fs):
         o_orderdate
     limit 100
     """
-
     customer = dd.read_parquet(dataset_path + "customer", filesystem=fs)
     orders = dd.read_parquet(dataset_path + "orders", filesystem=fs)
     lineitem = dd.read_parquet(dataset_path + "lineitem", filesystem=fs)

--- a/tests/tpch/dask_queries.py
+++ b/tests/tpch/dask_queries.py
@@ -956,13 +956,11 @@ def query_18(dataset_path, fs):
     )
     qnt_over_300 = qnt_over_300[qnt_over_300.l_quantity > 300]
 
-    table = (
-        orders.merge(
-            qnt_over_300, left_on="o_orderkey", right_on="l_orderkey", how="leftsemi"
-        )
-        .merge(lineitem, left_on="o_orderkey", right_on="l_orderkey", how="inner")
-        .merge(customer, left_on="o_custkey", right_on="c_custkey")
+    L = lineitem.merge(
+        qnt_over_300, left_on="l_orderkey", right_on="l_orderkey", how="leftsemi"
     )
+    C_O = customer.merge(orders, left_on="c_custkey", right_on="o_custkey", how="inner")
+    table = C_O.merge(L, left_on="o_orderkey", right_on="l_orderkey", how="inner")
 
     return (
         table.groupby(

--- a/tests/tpch/dask_queries.py
+++ b/tests/tpch/dask_queries.py
@@ -949,8 +949,8 @@ def query_18(dataset_path, fs):
     customer = dd.read_parquet(dataset_path + "customer", filesystem=fs)
     orders = dd.read_parquet(dataset_path + "orders", filesystem=fs)
     lineitem = dd.read_parquet(dataset_path + "lineitem", filesystem=fs)
-    # FIXME: https://github.com/dask-contrib/dask-expr/issues/867
 
+    # FIXME: https://github.com/dask-contrib/dask-expr/issues/867
     qnt_over_300 = (
         lineitem.groupby("l_orderkey").l_quantity.sum(split_out=True).reset_index()
     )


### PR DESCRIPTION
The join ordering we chose in query 18 is suboptimal and causes workers run OOM. This PR reimplements the query using Spark's join ordering. Note that Polars join ordering (https://github.com/coiled/benchmarks/commit/8eb24d068401269b665c485b27ee53d8b748da47) appears to be slightly faster (285s vs. 318s), but I do not want to optimize too much manually. Picking Spark's join ordering will provide the best apples-to-apples comparison against Dask's main competitor.