### PR TITLE
pytorch optuna xfail on correct asyncio TimeoutError

### DIFF
--- a/tests/workflows/test_pytorch_optuna.py
+++ b/tests/workflows/test_pytorch_optuna.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import tempfile
 import zipfile
+from asyncio.exceptions import TimeoutError
 
 import pytest
 from dask.distributed import Lock, PipInstall, get_worker


### PR DESCRIPTION
Followup to #1318 which was catching the wrong TimeoutError, should have been asyncio.exceptions.TimeoutError. 

Closes https://github.com/coiled/benchmarks/issues/1402

