### PR TITLE
A/B tests - calculate confidence interval against all combinations

### DIFF
--- a/.github/workflows/ab_tests.yml
+++ b/.github/workflows/ab_tests.yml
@@ -177,7 +177,7 @@ jobs:
           environment-file: ci/environment-dashboard.yml
 
       - name: Generate dashboards
-        run: python dashboard.py -d benchmark.db -o static -b baseline
+        run: python dashboard.py -d benchmark.db -o static -b all
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/dashboard.py
+++ b/dashboard.py
@@ -804,7 +804,12 @@ def main() -> None:
     make_barchart_html_report(df_recent, output_dir, by_test=False)
 
     baselines = []
-    for baseline in args.baseline:
+    if "all" in args.baseline:
+        baselines_input = list(df_recent["runtime"].unique())
+    else:
+        baselines_input = args.baseline
+
+    for baseline in baselines_input:
         has_baseline = make_ab_html_report(df_recent, output_dir, baseline)
         if has_baseline:
             baselines.append(baseline)


### PR DESCRIPTION
When running multiple configurations it is sometimes useful to caculate the differences between the various configurations and not just the baseline.

I think this is useful and cheap enough for us to do every time. 