### PR TITLE
Measure computation submission delay

### DIFF
--- a/tests/tpch/test_optimization.py
+++ b/tests/tpch/test_optimization.py
@@ -5,9 +5,8 @@ from . import dask_queries
 pytestmark = pytest.mark.tpch_dask
 
 
-@pytest.mark.parametrize(
-    "query",
-    [
+@pytest.fixture(
+    params=[
         1,
         2,
         3,
@@ -32,8 +31,20 @@ pytestmark = pytest.mark.tpch_dask
         22,
     ],
 )
+def query(request):
+    return request.param
+
+
 def test_optimization(query, dataset_path, fs, client):
     func = getattr(dask_queries, f"query_{query}")
     result = func(dataset_path, fs)
     # We need to inject .repartition(npartitions=1) which .compute() does under the hood
     result.repartition(npartitions=1).optimize()
+
+
+def test_delay_computation_start(query, dataset_path, fs, client):
+    func = getattr(dask_queries, f"query_{query}")
+    result = func(dataset_path, fs).optimize()
+    # Client.compute unblocks as soon as update_graph finishes, i.e. graph is
+    # submitted and parsed. This is the time until the dashboard kicks off
+    client.compute(result)


### PR DESCRIPTION
On top of the plain optimization, this measures the time it takes to submit the graph. This is typically the time it takes after hitting compute until the dashboard shows something.

This is likely skewed by caching as introduced in https://github.com/dask-contrib/dask-expr/pull/917 (the fsspec implementation also uses various caching layers) but I still believe this is added value