### PR TITLE
Fix fraction in Q11

### DIFF
--- a/tests/tpch/dask_queries.py
+++ b/tests/tpch/dask_queries.py
@@ -534,7 +534,7 @@ def query_10(dataset_path, fs):
     )
 
 
-def query_11(dataset_path, fs):
+def query_11(dataset_path, fs, scale=1):
     """
     select
         ps_partkey,
@@ -552,7 +552,7 @@ def query_11(dataset_path, fs):
     having
             sum(ps_supplycost * ps_availqty) > (
         select
-            sum(ps_supplycost * ps_availqty) * 0.0001
+            sum(ps_supplycost * ps_availqty) * 0.0001 / SF
         from
             partsupp,
             supplier,
@@ -574,7 +574,7 @@ def query_11(dataset_path, fs):
     ).merge(nation, left_on="s_nationkey", right_on="n_nationkey", how="inner")
     joined = joined[joined.n_name == "GERMANY"]
 
-    threshold = (joined.ps_supplycost * joined.ps_availqty).sum() * 0.0001
+    threshold = (joined.ps_supplycost * joined.ps_availqty).sum() * 0.0001 / scale
 
     joined["value"] = joined.ps_supplycost * joined.ps_availqty
 

--- a/tests/tpch/test_dask.py
+++ b/tests/tpch/test_dask.py
@@ -55,8 +55,8 @@ def test_query_10(client, dataset_path, fs):
 
 
 @pytest.mark.shuffle_p2p
-def test_query_11(client, dataset_path, fs):
-    dask_queries.query_11(dataset_path, fs).compute()
+def test_query_11(client, dataset_path, fs, scale):
+    dask_queries.query_11(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p

--- a/tests/tpch/test_duckdb.py
+++ b/tests/tpch/test_duckdb.py
@@ -468,7 +468,7 @@ def test_query_10(run, connection, dataset_path):
     run(_)
 
 
-def test_query_11(run, connection, dataset_path):
+def test_query_11(run, connection, dataset_path, scale):
     def _():
         connection().execute(
             f"""
@@ -491,7 +491,7 @@ def test_query_11(run, connection, dataset_path):
                 ps_partkey having
                         sum(ps_supplycost * ps_availqty) > (
                     select
-                        sum(ps_supplycost * ps_availqty) * 0.0001
+                        sum(ps_supplycost * ps_availqty) * {0.0001 / scale}
                     from
                         partsupp,
                         supplier,

--- a/tests/tpch/test_polars.py
+++ b/tests/tpch/test_polars.py
@@ -435,14 +435,14 @@ def test_query_10(run, restart, dataset_path):
     run(_)
 
 
-def test_query_11(run, restart, dataset_path):
+def test_query_11(run, restart, dataset_path, scale):
     def _():
         supplier_ds = read_data(dataset_path + "supplier")
         part_supp_ds = read_data(dataset_path + "partsupp")
         nation_ds = read_data(dataset_path + "nation")
 
         var_1 = "GERMANY"
-        var_2 = 0.0001
+        var_2 = 0.0001 / scale
 
         res_1 = (
             part_supp_ds.join(supplier_ds, left_on="ps_suppkey", right_on="s_suppkey")

--- a/tests/tpch/test_pyspark.py
+++ b/tests/tpch/test_pyspark.py
@@ -408,11 +408,11 @@ def test_query_10(spark, dataset_path):
     spark.sql(query).show()
 
 
-def test_query_11(spark, dataset_path):
+def test_query_11(spark, dataset_path, scale):
     for name in ("partsupp", "supplier", "nation"):
         register_table(spark, dataset_path, name)
 
-    query = """
+    query = f"""
     select
         ps_partkey,
         round(sum(ps_supplycost * ps_availqty), 2) as value
@@ -428,7 +428,7 @@ def test_query_11(spark, dataset_path):
         ps_partkey having
                 sum(ps_supplycost * ps_availqty) > (
             select
-                sum(ps_supplycost * ps_availqty) * 0.0001
+                sum(ps_supplycost * ps_availqty) * {0.0001 / scale}
             from
                 partsupp,
                 supplier,


### PR DESCRIPTION
> FRACTION is chosen as 0.0001 / SF.

according to the TPC-H specs. Not following this causes us to return empty results on larger scale factors.