### PR TITLE
Increase instance disk size for TPC-H SF 1000

### DIFF
--- a/tests/tpch/utils.py
+++ b/tests/tpch/utils.py
@@ -65,6 +65,7 @@ def get_cluster_spec(scale):
         return {
             "worker_vm_types": ["m6i.xlarge"],
             "n_workers": 32,
+            "worker_disk_size": 128,
             **everywhere,
         }
     elif scale == 10000:


### PR DESCRIPTION
Spark recently ran out of space (https://github.com/coiled/benchmarks/actions/runs/8231277279/job/22506263406#step:8:745). We should bump the disk size.