### PR TITLE
[TPC-H] Require `scale` argument for Dask queries

### DIFF
--- a/tests/tpch/dask_queries.py
+++ b/tests/tpch/dask_queries.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import dask.dataframe as dd
 
 
-def query_1(dataset_path, fs):
+def query_1(dataset_path, fs, scale):
     VAR1 = datetime(1998, 9, 2)
     lineitem_ds = dd.read_parquet(dataset_path + "lineitem", filesystem=fs)
 
@@ -40,7 +40,7 @@ def query_1(dataset_path, fs):
     return total.reset_index().sort_values(["l_returnflag", "l_linestatus"])
 
 
-def query_2(dataset_path, fs):
+def query_2(dataset_path, fs, scale):
     var1 = 15
     var2 = "BRASS"
     var3 = "EUROPE"
@@ -110,7 +110,7 @@ def query_2(dataset_path, fs):
     )
 
 
-def query_3(dataset_path, fs):
+def query_3(dataset_path, fs, scale):
     var1 = datetime.strptime("1995-03-15", "%Y-%m-%d")
     var2 = "BUILDING"
 
@@ -139,7 +139,7 @@ def query_3(dataset_path, fs):
     )
 
 
-def query_4(dataset_path, fs):
+def query_4(dataset_path, fs, scale):
     date1 = datetime.strptime("1993-10-01", "%Y-%m-%d")
     date2 = datetime.strptime("1993-07-01", "%Y-%m-%d")
 
@@ -163,7 +163,7 @@ def query_4(dataset_path, fs):
     return result_df
 
 
-def query_5(dataset_path, fs):
+def query_5(dataset_path, fs, scale):
     date1 = datetime.strptime("1994-01-01", "%Y-%m-%d")
     date2 = datetime.strptime("1995-01-01", "%Y-%m-%d")
 
@@ -192,7 +192,7 @@ def query_5(dataset_path, fs):
     return gb.reset_index().sort_values("revenue", ascending=False)
 
 
-def query_6(dataset_path, fs):
+def query_6(dataset_path, fs, scale):
     date1 = datetime.strptime("1994-01-01", "%Y-%m-%d")
     date2 = datetime.strptime("1995-01-01", "%Y-%m-%d")
     var3 = 24
@@ -212,7 +212,7 @@ def query_6(dataset_path, fs):
     return revenue.sum().to_frame("revenue")
 
 
-def query_7(dataset_path, fs):
+def query_7(dataset_path, fs, scale):
     var1 = datetime.strptime("1995-01-01", "%Y-%m-%d")
     var2 = datetime.strptime("1997-01-01", "%Y-%m-%d")
 
@@ -307,7 +307,7 @@ def query_7(dataset_path, fs):
     )
 
 
-def query_8(dataset_path, fs):
+def query_8(dataset_path, fs, scale):
     var1 = datetime.strptime("1995-01-01", "%Y-%m-%d")
     var2 = datetime.strptime("1997-01-01", "%Y-%m-%d")
 
@@ -365,7 +365,7 @@ def query_8(dataset_path, fs):
     return final.sort_values(by=["o_year"], ascending=[True])[["o_year", "mkt_share"]]
 
 
-def query_9(dataset_path, fs):
+def query_9(dataset_path, fs, scale):
     """
     select
         nation,
@@ -440,7 +440,7 @@ def query_9(dataset_path, fs):
     )
 
 
-def query_10(dataset_path, fs):
+def query_10(dataset_path, fs, scale):
     """
     select
         c_custkey,
@@ -534,7 +534,7 @@ def query_10(dataset_path, fs):
     )
 
 
-def query_11(dataset_path, fs, scale=1):
+def query_11(dataset_path, fs, scale):
     """
     select
         ps_partkey,
@@ -590,7 +590,7 @@ def query_11(dataset_path, fs, scale=1):
     return res
 
 
-def query_12(dataset_path, fs):
+def query_12(dataset_path, fs, scale):
     """
     select
         l_shipmode,
@@ -650,7 +650,7 @@ def query_12(dataset_path, fs):
     )
 
 
-def query_13(dataset_path, fs):
+def query_13(dataset_path, fs, scale):
     """
     select
         c_count, count(*) as custdist
@@ -695,7 +695,7 @@ def query_13(dataset_path, fs):
     )
 
 
-def query_14(dataset_path, fs):
+def query_14(dataset_path, fs, scale):
     """
     select
         round(100.00 * sum(case
@@ -742,7 +742,7 @@ def query_14(dataset_path, fs):
     )
 
 
-def query_15(dataset_path, fs):
+def query_15(dataset_path, fs, scale):
     """
     DDL:
     create temp view revenue (supplier_no, total_revenue) as
@@ -806,7 +806,7 @@ def query_15(dataset_path, fs):
     ].sort_values(by="s_suppkey")
 
 
-def query_16(dataset_path, fs):
+def query_16(dataset_path, fs, scale):
     """
     select
         p_brand,
@@ -866,7 +866,7 @@ def query_16(dataset_path, fs):
     )
 
 
-def query_17(dataset_path, fs):
+def query_17(dataset_path, fs, scale):
     """
     select
         round(sum(l_extendedprice) / 7.0, 2) as avg_yearly
@@ -911,7 +911,7 @@ def query_17(dataset_path, fs):
     )
 
 
-def query_18(dataset_path, fs):
+def query_18(dataset_path, fs, scale):
     """
     select
         c_name,
@@ -975,7 +975,7 @@ def query_18(dataset_path, fs):
     )
 
 
-def query_19(dataset_path, fs):
+def query_19(dataset_path, fs, scale):
     """
     select
         round(sum(l_extendedprice* (1 - l_discount)), 2) as revenue
@@ -1052,7 +1052,7 @@ def query_19(dataset_path, fs):
     )
 
 
-def query_20(dataset_path, fs):
+def query_20(dataset_path, fs, scale):
     """
     select
         s_name,
@@ -1131,7 +1131,7 @@ def query_20(dataset_path, fs):
     return q_final[["s_name", "s_address"]].sort_values("s_name", ascending=True)
 
 
-def query_21(dataset_path, fs):
+def query_21(dataset_path, fs, scale):
     """
     select
         s_name,
@@ -1219,7 +1219,7 @@ def query_21(dataset_path, fs):
     )
 
 
-def query_22(dataset_path, fs):
+def query_22(dataset_path, fs, scale):
     """
     select
         cntrycode,

--- a/tests/tpch/test_correctness.py
+++ b/tests/tpch/test_correctness.py
@@ -139,5 +139,7 @@ def test_dask_results(query, local, answers_path, client):
     from . import dask_queries
 
     func = getattr(dask_queries, f"query_{query}")
-    result = func(get_dataset_path(local, VERIFICATION_SCALE), None).compute()
+    result = func(
+        get_dataset_path(local, VERIFICATION_SCALE), None, VERIFICATION_SCALE
+    ).compute()
     verify_result(result, query, answers_path)

--- a/tests/tpch/test_dask.py
+++ b/tests/tpch/test_dask.py
@@ -1,57 +1,57 @@
 import pytest
 
-from . import dask_queries
-
 pytestmark = pytest.mark.tpch_dask
 
 dd = pytest.importorskip("dask.dataframe")
 
-
-def test_query_1(client, dataset_path, fs):
-    dask_queries.query_1(dataset_path, fs).compute()
+from . import dask_queries  # noqa: E402
 
 
-@pytest.mark.shuffle_p2p
-def test_query_2(client, dataset_path, fs):
-    dask_queries.query_2(dataset_path, fs).compute()
+def test_query_1(client, dataset_path, fs, scale):
+    dask_queries.query_1(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_3(client, dataset_path, fs):
-    dask_queries.query_3(dataset_path, fs).compute()
+def test_query_2(client, dataset_path, fs, scale):
+    dask_queries.query_2(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_4(client, dataset_path, fs):
-    dask_queries.query_4(dataset_path, fs).compute()
+def test_query_3(client, dataset_path, fs, scale):
+    dask_queries.query_3(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_5(client, dataset_path, fs):
-    dask_queries.query_5(dataset_path, fs).compute()
-
-
-def test_query_6(client, dataset_path, fs):
-    dask_queries.query_6(dataset_path, fs).compute()
+def test_query_4(client, dataset_path, fs, scale):
+    dask_queries.query_4(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_7(client, dataset_path, fs):
-    dask_queries.query_7(dataset_path, fs).compute()
+def test_query_5(client, dataset_path, fs, scale):
+    dask_queries.query_5(dataset_path, fs, scale).compute()
 
 
-def test_query_8(client, dataset_path, fs):
-    dask_queries.query_8(dataset_path, fs).compute()
-
-
-@pytest.mark.shuffle_p2p
-def test_query_9(client, dataset_path, fs):
-    dask_queries.query_9(dataset_path, fs).compute()
+def test_query_6(client, dataset_path, fs, scale):
+    dask_queries.query_6(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_10(client, dataset_path, fs):
-    dask_queries.query_10(dataset_path, fs).compute()
+def test_query_7(client, dataset_path, fs, scale):
+    dask_queries.query_7(dataset_path, fs, scale).compute()
+
+
+def test_query_8(client, dataset_path, fs, scale):
+    dask_queries.query_8(dataset_path, fs, scale).compute()
+
+
+@pytest.mark.shuffle_p2p
+def test_query_9(client, dataset_path, fs, scale):
+    dask_queries.query_9(dataset_path, fs, scale).compute()
+
+
+@pytest.mark.shuffle_p2p
+def test_query_10(client, dataset_path, fs, scale):
+    dask_queries.query_10(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
@@ -60,54 +60,54 @@ def test_query_11(client, dataset_path, fs, scale):
 
 
 @pytest.mark.shuffle_p2p
-def test_query_12(client, dataset_path, fs):
-    dask_queries.query_12(dataset_path, fs).compute()
+def test_query_12(client, dataset_path, fs, scale):
+    dask_queries.query_12(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_13(client, dataset_path, fs):
-    dask_queries.query_13(dataset_path, fs).compute()
+def test_query_13(client, dataset_path, fs, scale):
+    dask_queries.query_13(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_14(client, dataset_path, fs):
-    dask_queries.query_14(dataset_path, fs).compute()
+def test_query_14(client, dataset_path, fs, scale):
+    dask_queries.query_14(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_15(client, dataset_path, fs):
-    dask_queries.query_15(dataset_path, fs).compute()
+def test_query_15(client, dataset_path, fs, scale):
+    dask_queries.query_15(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_16(client, dataset_path, fs):
-    dask_queries.query_16(dataset_path, fs).compute()
+def test_query_16(client, dataset_path, fs, scale):
+    dask_queries.query_16(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_17(client, dataset_path, fs):
-    dask_queries.query_17(dataset_path, fs).compute()
+def test_query_17(client, dataset_path, fs, scale):
+    dask_queries.query_17(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_18(client, dataset_path, fs):
-    dask_queries.query_18(dataset_path, fs).compute()
+def test_query_18(client, dataset_path, fs, scale):
+    dask_queries.query_18(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_19(client, dataset_path, fs):
-    dask_queries.query_19(dataset_path, fs).compute()
+def test_query_19(client, dataset_path, fs, scale):
+    dask_queries.query_19(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_20(client, dataset_path, fs):
-    dask_queries.query_20(dataset_path, fs).compute()
+def test_query_20(client, dataset_path, fs, scale):
+    dask_queries.query_20(dataset_path, fs, scale).compute()
 
 
 @pytest.mark.shuffle_p2p
-def test_query_21(client, dataset_path, fs):
-    dask_queries.query_21(dataset_path, fs).compute()
+def test_query_21(client, dataset_path, fs, scale):
+    dask_queries.query_21(dataset_path, fs, scale).compute()
 
 
-def test_query_22(client, dataset_path, fs):
-    dask_queries.query_22(dataset_path, fs).compute()
+def test_query_22(client, dataset_path, fs, scale):
+    dask_queries.query_22(dataset_path, fs, scale).compute()

--- a/tests/tpch/test_optimization.py
+++ b/tests/tpch/test_optimization.py
@@ -35,9 +35,9 @@ def query(request):
     return request.param
 
 
-def test_optimization(query, dataset_path, fs, client):
+def test_optimization(query, dataset_path, fs, client, scale):
     func = getattr(dask_queries, f"query_{query}")
-    result = func(dataset_path, fs)
+    result = func(dataset_path, fs, scale)
     # We need to inject .repartition(npartitions=1) which .compute() does under the hood
     result.repartition(npartitions=1).optimize()
 

--- a/tests/tpch/test_optimization.py
+++ b/tests/tpch/test_optimization.py
@@ -42,9 +42,9 @@ def test_optimization(query, dataset_path, fs, client):
     result.repartition(npartitions=1).optimize()
 
 
-def test_delay_computation_start(query, dataset_path, fs, client):
+def test_delay_computation_start(query, dataset_path, fs, client, scale):
     func = getattr(dask_queries, f"query_{query}")
-    result = func(dataset_path, fs).optimize()
+    result = func(dataset_path, fs, scale).optimize()
     # Client.compute unblocks as soon as update_graph finishes, i.e. graph is
     # submitted and parsed. This is the time until the dashboard kicks off
     client.compute(result)


### PR DESCRIPTION
Having a default for Q11 could lead to the scale used for the data and the query diverging. Requiring it for each query avoids special casing. 