### PR TITLE
Tag all tests using spans

### DIFF
--- a/tests/tpch/conftest.py
+++ b/tests/tpch/conftest.py
@@ -206,6 +206,7 @@ def client(
     testrun_uid,
     cluster_kwargs,
     benchmark_time,
+    span,
     restart,
     scale,
     local,

--- a/tests/tpch/test_correctness.py
+++ b/tests/tpch/test_correctness.py
@@ -70,6 +70,7 @@ def client(
     testrun_uid,
     cluster_kwargs,
     benchmark_time,
+    span,
     restart,
     local,
     query,


### PR DESCRIPTION
Spans are based on annotations, and annotations don't work with dask-expr.
However this caveat applies only to _nesting_ annotations in the layers - any annotations that are active when you hit compute/persist will be captured.

![image](https://github.com/coiled/benchmarks/assets/6213168/6e4415a1-b81d-4e45-b680-a96fb8b65adc)
![image](https://github.com/coiled/benchmarks/assets/6213168/ce292356-49fe-4507-80b2-d51cad163167)
