### PR TITLE
Fix pyspark local execution

### DIFF
--- a/tests/tpch/generate_data.py
+++ b/tests/tpch/generate_data.py
@@ -76,7 +76,7 @@ def generate(
             with cluster.get_client() as client:
                 tpch_from_client(client, **kwargs)
     else:
-        with dask.distributed.Client() as client:
+        with dask.distributed.Client(threads_per_worker=1, n_workers=4) as client:
             tpch_from_client(client, **kwargs)
 
             # TODO: hack to suppress noisy "CommClosedError"s

--- a/tests/tpch/utils.py
+++ b/tests/tpch/utils.py
@@ -13,6 +13,7 @@ def get_dataset_path(local, scale):
     }
     local_paths = {
         1: "./tpch-data/scale-1/",
+        5: "./tpch-data/scale-5/",
         10: "./tpch-data/scale-10/",
         100: "./tpch-data/scale-100/",
     }


### PR DESCRIPTION
I've tried this with scale 5 and 10 data w/o trouble after verifying the current state is broken.

My machine has 65G so the logic gives  ~23G to executors, and have tried capping that to 5G per executor and it still worked. 

I somewhat arbitrarily assigned `n_executors = 2`, could very well be a single executor or something else. I'm not sure what might be preferred here by others.