### PR TITLE
Add link to TPC-H README on main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ aws s3 cp s3://coiled-runtime-ci/benchmarks/benchmark.db ./benchmark.db
 pytest --benchmark
 ```
 
+### TPC-H Benchmarks
+
+To get going with the TPC-H benchmarks, checkout the [README here](./tests/tpch/README.md)
+
 ### Changing the benchmark schema
 
 You can add, remove, or modify columns by editing the SQLAlchemy schema in `benchmark_schema.py`.


### PR DESCRIPTION
Will close #1493 

Given the setting up of TPC-H benchmarking and related information is 'buried' in `tests/tpch`, I think it's useful to have a link to it on the main README.