### PR TITLE
bump polars version

### DIFF
--- a/ci/requirements-1tpch-non-dask.in
+++ b/ci/requirements-1tpch-non-dask.in
@@ -9,5 +9,5 @@ grpcio-status==1.62.1
 protobuf==5.26.0
 
 # Other TPCH tests
-polars==0.20.16
+polars==0.20.26
 duckdb==0.10.1


### PR DESCRIPTION
In case we can/want to rerun polars numbers with https://github.com/coiled/benchmarks/pull/1512 we can also include a more recent version
