### PR TITLE
Truncate `test_run` table in `benchmark.db` to the last 90 days

### DIFF
--- a/ci/scripts/combine-dbs.sh
+++ b/ci/scripts/combine-dbs.sh
@@ -16,7 +16,6 @@ DB_NAME=benchmark.tmp.db alembic upgrade head
 # Delete old records and vacuum to reduce on-disk size
 sqlite3 benchmark.tmp.db <<EOF
 DELETE FROM test_run WHERE session_id not in (SELECT DISTINCT session_id FROM test_run WHERE start > date('now', '-90 days'));
-DELETE FROM tpch_run WHERE session_id not in (SELECT DISTINCT session_id FROM tpch_run WHERE start > date('now', '-90 days'));
 VACUUM;
 EOF
 # Merge in the individual job dbs into our working copy

--- a/ci/scripts/combine-dbs.sh
+++ b/ci/scripts/combine-dbs.sh
@@ -13,6 +13,12 @@ else
 fi
 DB_NAME=benchmark.tmp.db alembic upgrade head
 
+# Delete old records and vacuum to reduce on-disk size
+sqlite3 benchmark.tmp.db <<EOF
+DELETE FROM test_run WHERE session_id not in (SELECT DISTINCT session_id FROM test_run WHERE start > date('now', '-90 days'));
+DELETE FROM tpch_run WHERE session_id not in (SELECT DISTINCT session_id FROM tpch_run WHERE start > date('now', '-90 days'));
+VACUUM;
+EOF
 # Merge in the individual job dbs into our working copy
 for FILE in $(find . -name "*.db")
 do


### PR DESCRIPTION
This PR truncates the `test_run` table in the `benchmark.db` to the runs of the last 90 days. This reduces the size of the database from ~10 GB to ~500 MB and keeps it at that level. Currently, CI workers are unable to process the existing DB causing CI to fail since June 1st.

We don't truncate `tpch_run` since we don't store `start`.