### PR TITLE
Use 50 GB Parquet+PyArrow dataset for H2O tests on CI

### DIFF
--- a/AB_environments/config.yaml
+++ b/AB_environments/config.yaml
@@ -35,8 +35,8 @@ h2o_datasets:
   # - 0.5 GB (parquet)
   # - 5 GB (parquet)
   # - 50 GB (parquet)
-  - 5 GB (parquet+pyarrow)
-  # - 50 GB (parquet+pyarrow)
+  # - 5 GB (parquet+pyarrow)
+  - 50 GB (parquet+pyarrow)
   # - 500 GB (parquet+pyarrow)
 
 # AWS implements limiters to how many EC2 instances you can spawn in parallel on the

--- a/tests/benchmarks/test_h2o.py
+++ b/tests/benchmarks/test_h2o.py
@@ -31,7 +31,7 @@ if enabled_datasets is not None:
         raise ValueError("Unknown h2o dataset(s): ", unknown_datasets)
 else:
     enabled_datasets = {
-        "5 GB (parquet)",
+        "50 GB (parquet+pyarrow)",
     }
 
 


### PR DESCRIPTION
Similar to #1530, the 5 GB dataset feels too small to benchmark behavior we care about.