### PR TITLE
Add marker to exclude non-Dask TPC-H tests by default

### DIFF
--- a/AB_environments/config.yaml
+++ b/AB_environments/config.yaml
@@ -22,7 +22,7 @@ targets:
 
 # pytest markers or marker expressions. See setup.cfg for available ones.
 # Leave blank to run all marked and unmarked tests.
-markers:
+markers: not tpch_nondask
 # markers: shuffle_p2p
 # markers: shuffle_p2p or shuffle_tasks
 # markers: not shuffle_tasks


### PR DESCRIPTION
By adding this marker by default, we exclude non-Dask TPC-H from A/B tests even if `tests/tpch` is included.