### PR TITLE
Tag coiled.function in TPC-H

### DIFF
--- a/tests/tpch/conftest.py
+++ b/tests/tpch/conftest.py
@@ -315,7 +315,7 @@ def machine_spec(scale):
 
 
 @pytest.fixture(scope="module")
-def module_run(local, module, scale, name, machine_spec):
+def module_run(local, module, scale, name, machine_spec, github_cluster_tags):
     if local:
 
         def _run(function):
@@ -325,7 +325,11 @@ def module_run(local, module, scale, name, machine_spec):
 
     else:
 
-        @coiled.function(**machine_spec, name=f"tpch-{module}-{scale}-{name}")
+        @coiled.function(
+            **machine_spec,
+            name=f"tpch-{module}-{scale}-{name}",
+            tags=github_cluster_tags,
+        )
         def _run(function):
             return function()
 


### PR DESCRIPTION
This makes sure that `coiled.function` are tagged appropriately.