### PR TITLE
Add missing bottleneck package to environments

### DIFF
--- a/AB_environments/AB_baseline.conda.yaml
+++ b/AB_environments/AB_baseline.conda.yaml
@@ -48,6 +48,7 @@ dependencies:
   - rioxarray ==0.17.0
   - h5netcdf ==1.3.0
   - xesmf ==0.8.7
+  - bottleneck ==1.4.1
   # End copy-paste
 
   - pip:

--- a/AB_environments/AB_sample.conda.yaml
+++ b/AB_environments/AB_sample.conda.yaml
@@ -54,6 +54,7 @@ dependencies:
   - rioxarray ==0.17.0
   - h5netcdf ==1.3.0
   - xesmf ==0.8.7
+  - bottleneck ==1.4.1
   # End copy-paste
 
   - pip:

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -50,6 +50,7 @@ dependencies:
   - rioxarray ==0.17.0
   - h5netcdf ==1.3.0
   - xesmf ==0.8.7
+  - bottleneck ==1.4.1
 
 ########################################################
 # PLEASE READ:


### PR DESCRIPTION
`bottleneck` is used in `tests/geospatial/test_climatology.py::test_highlevel_api`