### PR TITLE
Collect scheduler memray profiles when benchmarking geospatial tests

### DIFF
--- a/.github/workflows/ab_tests.yml
+++ b/.github/workflows/ab_tests.yml
@@ -107,7 +107,7 @@ jobs:
           CLUSTER_KWARGS: AB_environments/${{ matrix.runtime-version }}.cluster.yaml
           H2O_DATASETS: ${{ matrix.h2o_datasets }}
           MEMRAY_PROFILE: "scheduler"
-        run: pytest --benchmark ${{ matrix.pytest_args }}
+        run: pytest --benchmark --memray $MEMRAY_PROFILE ${{ matrix.pytest_args }}
 
       - name: Dump coiled.Cluster kwargs
         run: cat cluster_kwargs.merged.yaml

--- a/.github/workflows/ab_tests.yml
+++ b/.github/workflows/ab_tests.yml
@@ -106,6 +106,7 @@ jobs:
           DB_NAME: ${{ matrix.runtime-version }}-${{ matrix.repeat }}.db
           CLUSTER_KWARGS: AB_environments/${{ matrix.runtime-version }}.cluster.yaml
           H2O_DATASETS: ${{ matrix.h2o_datasets }}
+          MEMRAY_PROFILE: "scheduler"
         run: pytest --benchmark ${{ matrix.pytest_args }}
 
       - name: Dump coiled.Cluster kwargs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,7 +143,7 @@ jobs:
           DASK_DATAFRAME__QUERY_PLANNING: True
           MEMRAY_PROFILE: "scheduler"
         run: |
-          pytest --benchmark -n 4 --dist loadscope ${{ env.PYTEST_MARKERS }} ${{ matrix.pytest_args }}
+          pytest --benchmark -n 4 --dist loadscope --memray $MEMRAY_PROFILE ${{ env.PYTEST_MARKERS }} ${{ matrix.pytest_args }}
 
       - name: Dump coiled.Cluster kwargs
         run: cat cluster_kwargs.merged.yaml || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,6 +141,7 @@ jobs:
           COILED_RUNTIME_VERSION: ${{ matrix.runtime-version }}
           DB_NAME: ${{ matrix.name_prefix }}-${{ matrix.os }}-py${{ matrix.python_version }}.db
           DASK_DATAFRAME__QUERY_PLANNING: True
+          MEMRAY_PROFILE: "scheduler"
         run: |
           pytest --benchmark -n 4 --dist loadscope ${{ env.PYTEST_MARKERS }} ${{ matrix.pytest_args }}
 

--- a/.github/workflows/tpch.yml
+++ b/.github/workflows/tpch.yml
@@ -105,7 +105,7 @@ jobs:
         pytest --benchmark \
             ${{ env.PYTEST_BENCHMARKS }} \
             -n 4 --dist loadscope \
-            --scale ${{ inputs.scale }}
+            --scale ${{ inputs.scale }} \
 
     - name: Upload benchmark results
       uses: actions/upload-artifact@v4

--- a/AB_environments/AB_baseline.conda.yaml
+++ b/AB_environments/AB_baseline.conda.yaml
@@ -54,6 +54,7 @@ dependencies:
   - pystac-client ==0.8.3
   - odc-stac ==0.3.10
   - adlfs ==2024.7.0
+  - memray ==1.13.4
   # End copy-paste
 
   - pip:

--- a/AB_environments/AB_sample.conda.yaml
+++ b/AB_environments/AB_sample.conda.yaml
@@ -60,6 +60,7 @@ dependencies:
   - pystac-client ==0.8.3
   - odc-stac ==0.3.10
   - adlfs ==2024.7.0
+  - memray ==1.13.4
   # End copy-paste
 
   - pip:

--- a/alembic/versions/1095dfdfc4ae_add_column_for_memray_profiles_url.py
+++ b/alembic/versions/1095dfdfc4ae_add_column_for_memray_profiles_url.py
@@ -1,0 +1,24 @@
+"""Add column for Memray profiles url
+
+Revision ID: 1095dfdfc4ae
+Revises: 2d2405ad763b
+Create Date: 2024-10-23 11:11:15.238042
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1095dfdfc4ae'
+down_revision = '2d2405ad763b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('test_run', sa.Column('memray_profiles_url', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("test_run", "memray_profiles_url")

--- a/benchmark_schema.py
+++ b/benchmark_schema.py
@@ -62,6 +62,7 @@ class TestRun(Base):
     # Artifacts
     performance_report_url = Column(String, nullable=True)  # Not yet collected
     cluster_dump_url = Column(String, nullable=True)
+    memray_profiles_url = Column(String, nullable=True)
 
 
 class TPCHRun(Base):

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -56,6 +56,7 @@ dependencies:
   - pystac-client ==0.8.3
   - odc-stac ==0.3.10
   - adlfs ==2024.7.0
+  - memray ==1.13.4
 
 ########################################################
 # PLEASE READ:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -884,7 +884,7 @@ def memray_profile(
         memray_option = pytestconfig.getoption("--memray")
 
         if memray_option == "none":
-            yield
+            yield contextlib.nullcontext
         elif memray_option != "scheduler":
             raise ValueError(f"Unhandled value for --memray: {memray_option}")
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -663,9 +663,9 @@ def s3_factory(s3_storage_options):
 
 
 @pytest.fixture(scope="session")
-def s3_memray_profiles(s3):
-    profiles_url = f"{S3_BUCKET}/memray-profiles"
-    # Ensure that the memray-profiles directory exists,
+def s3_performance(s3):
+    profiles_url = f"{S3_BUCKET}/performance"
+    # Ensure that the performance directory exists,
     # but do NOT remove it as multiple test runs could be
     # accessing it at the same time
     s3.mkdirs(profiles_url, exist_ok=True)
@@ -693,8 +693,8 @@ def s3_url(s3, s3_scratch, test_name_uuid):
 
 
 @pytest.fixture(scope="function")
-def s3_memray_profiles_url(s3, s3_memray_profiles, test_name_uuid):
-    url = f"{s3_memray_profiles}/{test_name_uuid}"
+def s3_performance_url(s3, s3_performance, test_name_uuid):
+    url = f"{s3_performance}/{test_name_uuid}"
     s3.mkdirs(url, exist_ok=False)
     return url
 
@@ -867,7 +867,7 @@ def memory_multiplier(request):
 def memray_profile(
     pytestconfig,
     s3,
-    s3_memray_profiles_url,
+    s3_performance_url,
     s3_storage_options,
     test_run_benchmark,
     tmp_path,
@@ -894,7 +894,9 @@ def memray_profile(
                 with tarfile.open(archive, mode="w:gz") as tar:
                     for item in profiles_path.iterdir():
                         tar.add(item, arcname=item.name)
-                test_run_benchmark.memray_profiles_url = s3_memray_profiles_url
-                s3.put(archive, s3_memray_profiles_url)
+                test_run_benchmark.memray_profiles_url = str(
+                    s3_performance_url / "memray.tar.gz"
+                )
+                s3.put(archive, s3_performance_url)
 
         yield _memray_profile

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,12 +71,6 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
-        "--performance-report",
-        action="store_true",
-        help="Collect performance report for tests",
-    )
-
-    parser.addoption(
         "--memray",
         action="store",
         default="scheduler",

--- a/tests/geospatial/conftest.py
+++ b/tests/geospatial/conftest.py
@@ -27,7 +27,7 @@ def cluster_name(request, scale):
 
 
 @pytest.fixture()
-def client_factory(cluster_name, github_cluster_tags, benchmark_all):
+def client_factory(cluster_name, github_cluster_tags, benchmark_all, memray_profile):
     import contextlib
 
     @contextlib.contextmanager
@@ -41,7 +41,7 @@ def client_factory(cluster_name, github_cluster_tags, benchmark_all):
             if env:
                 cluster.send_private_envs(env=env)
             with cluster.get_client() as client:
-                with benchmark_all(client):
+                with memray_profile(client), benchmark_all(client):
                     yield client
 
     return _


### PR DESCRIPTION
Closes #1567 

Note: This requires tests to be run with the `--benchmark` flag