### PR TITLE
Allow collection of performance reports for geospatial benchmarks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,12 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
+        "--performance-report",
+        action="store_true",
+        help="Collect performance report for tests",
+    )
+
+    parser.addoption(
         "--memray",
         action="store",
         default="scheduler",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -925,7 +925,7 @@ def performance_report(
         yield
     else:
         if not pytestconfig.getoption("--performance-report"):
-            yield
+            yield contextlib.nullcontext
         else:
 
             @contextlib.contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -910,3 +910,33 @@ def memray_profile(
                     s3.put(archive, s3_performance_url)
 
             yield _memray_profile
+
+
+@pytest.fixture
+def performance_report(
+    pytestconfig,
+    s3,
+    s3_performance_url,
+    s3_storage_options,
+    test_run_benchmark,
+    tmp_path,
+):
+    if not test_run_benchmark:
+        yield
+    else:
+        if not pytestconfig.getoption("--performance-report"):
+            yield
+        else:
+
+            @contextlib.contextmanager
+            def _performance_report():
+                try:
+                    filename = f"{s3_performance_url}/performance_report.html.gz"
+                    with distributed.performance_report(
+                        filename=filename, storage_options=s3_storage_options
+                    ):
+                        yield
+                finally:
+                    test_run_benchmark.performance_report_url = filename
+
+            yield _performance_report

--- a/tests/geospatial/conftest.py
+++ b/tests/geospatial/conftest.py
@@ -27,7 +27,9 @@ def cluster_name(request, scale):
 
 
 @pytest.fixture()
-def client_factory(cluster_name, github_cluster_tags, benchmark_all, memray_profile):
+def client_factory(
+    cluster_name, github_cluster_tags, benchmark_all, memray_profile, performance_report
+):
     import contextlib
 
     @contextlib.contextmanager
@@ -43,7 +45,9 @@ def client_factory(cluster_name, github_cluster_tags, benchmark_all, memray_prof
             with cluster.get_client() as client:
                 # FIXME https://github.com/coiled/platform/issues/103
                 client.wait_for_workers(n_workers)
-                with memray_profile(client), benchmark_all(client):
+                with performance_report(), memray_profile(client), benchmark_all(
+                    client
+                ):
                     yield client
 
     return _


### PR DESCRIPTION
To use this, execute benchmarks with `--benchmark --performance-report`
