### PR TITLE
Fix cleanup of object-store directories

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -669,7 +669,10 @@ def s3_url(s3, s3_scratch, test_name_uuid):
     try:
         yield url
     finally:
-        s3.rm(url, recursive=True)
+        try:
+            s3.rm(url, recursive=True)
+        except FileNotFoundError:
+            pass
 
 
 GCS_REGION = "us-central1"
@@ -698,7 +701,10 @@ def gcs_url(gcs, gcs_scratch, test_name_uuid):
     try:
         yield url
     finally:
-        gcs.rm(url, recursive=True)
+        try:
+            gcs.rm(url, recursive=True)
+        except FileNotFoundError:
+            pass
 
 
 @pytest.fixture(scope="session")
@@ -724,7 +730,10 @@ def az_url(az, az_scratch, test_name_uuid):
     try:
         yield url
     finally:
-        az.rm(url, recursive=True)
+        try:
+            az.rm(url, recursive=True)
+        except FileNotFoundError:
+            pass
 
 
 # this code was taken from pytest docs


### PR DESCRIPTION
"Folders" might not exist in object stores, so let's not fail when that's the case because no file has been added at that location.