### PR TITLE
Recalibrate scales of regridding benchmark

### DIFF
--- a/tests/geospatial/test_regridding.py
+++ b/tests/geospatial/test_regridding.py
@@ -1,15 +1,12 @@
-import pytest
 from coiled.credentials.google import CoiledShippedCredentials
 
 from tests.geospatial.workloads.regridding import xesmf
 
 
-@pytest.mark.parametrize("output_resolution", [1.5, 0.1])
 def test_xesmf(
     gcs_url,
     scale,
     client_factory,
-    output_resolution,
     cluster_kwargs={
         "workspace": "dask-benchmarks-gcp",
         "region": "us-central1",
@@ -17,8 +14,8 @@ def test_xesmf(
     },
     scale_kwargs={
         "small": {"n_workers": 10},
-        "medium": {"n_workers": 100},
-        "large": {"n_workers": 100},
+        "medium": {"n_workers": 10},
+        "large": {"n_workers": 10},
     },
 ):
     with client_factory(
@@ -26,7 +23,6 @@ def test_xesmf(
     ) as client:  # noqa: F841
         result = xesmf(
             scale=scale,
-            output_resolution=output_resolution,
             storage_url=gcs_url,
             storage_options={"token": CoiledShippedCredentials()},
         )

--- a/tests/geospatial/workloads/regridding.py
+++ b/tests/geospatial/workloads/regridding.py
@@ -8,30 +8,30 @@ from dask.delayed import Delayed
 
 def xesmf(
     scale: Literal["small", "medium", "large"],
-    output_resolution: float,
     storage_url: str,
     storage_options: dict[str, Any],
 ) -> Delayed:
     ds = xr.open_zarr(
         "gs://weatherbench2/datasets/era5/1959-2023_01_10-full_37-1h-0p25deg-chunk-1.zarr",
     )
-
+    # Fixed time range and variable as the interesting part of this benchmark scales with the
+    # regridding matrix
+    time_range = slice("2020-01-01", "2021-12-31")
+    variables = ["sea_surface_temperature"]
     if scale == "small":
-        # 101.83 GiB (small)
-        time_range = slice("2020-01-01", "2022-12-31")
-        variables = ["sea_surface_temperature"]
+        # Regridding from a resolution of 0.25 degress to 1 degrees
+        # results in 4 MiB weight matrix
+        output_resolution = 1
     elif scale == "medium":
-        # 2.12 TiB (medium)
-        time_range = slice("1959-01-01", "2022-12-31")
-        variables = ["sea_surface_temperature"]
+        # Regridding from a resolution of 0.25 degrees to 0.2 degrees
+        # results in 100 MiB weight matrix
+        output_resolution = 0.2
     else:
-        # 4.24 TiB (large)
-        # This currently doesn't complete successfully.
-        time_range = slice("1959-01-01", "2022-12-31")
-        variables = ["sea_surface_temperature", "snow_depth"]
+        # Regridding from a resolution of 0.25 degrees to 0.05 degrees
+        # results in 1.55 GiB weight matrix
+        output_resolution = 0.05
     ds = ds[variables].sel(time=time_range)
 
-    # 240x121
     out_grid = xr.Dataset(
         {
             "latitude": (

--- a/tests/geospatial/workloads/regridding.py
+++ b/tests/geospatial/workloads/regridding.py
@@ -16,8 +16,7 @@ def xesmf(
     )
     # Fixed time range and variable as the interesting part of this benchmark scales with the
     # regridding matrix
-    time_range = slice("2020-01-01", "2021-12-31")
-    variables = ["sea_surface_temperature"]
+    ds = ds[["sea_surface_temperature"]].sel(time=slice("2020-01-01", "2021-12-31"))
     if scale == "small":
         # Regridding from a resolution of 0.25 degress to 1 degrees
         # results in 4 MiB weight matrix
@@ -30,7 +29,6 @@ def xesmf(
         # Regridding from a resolution of 0.25 degrees to 0.05 degrees
         # results in 1.55 GiB weight matrix
         output_resolution = 0.05
-    ds = ds[variables].sel(time=time_range)
 
     out_grid = xr.Dataset(
         {


### PR DESCRIPTION
For this benchmark, the most interesting scaling dimension is the size of the weight matrix which depends on the output resolution. We should, therefore, scale it along this dimension.

cc @phofl