### PR TITLE
Fix CI run for Windows stability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python_version: ["3.10"]
-        pytest_args: [tests --ignore=tests/tpch]
+        pytest_args: [tests --ignore=tests/tpch --ignore=tests/geospatial]
         extra-env: [""]
         name_prefix: [tests]
         include:

--- a/ci/environment-geospatial.yml
+++ b/ci/environment-geospatial.yml
@@ -1,0 +1,6 @@
+# This is an addition to ci/environment.yml.
+# Add dependencies exclusively needed to run geospatial tests on dask competitors.
+channels:
+  - conda-forge
+dependencies:
+  - memray ==1.13.4

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -57,7 +57,6 @@ dependencies:
   - pystac-client ==0.8.3
   - odc-stac ==0.3.10
   - adlfs ==2024.7.0
-  - memray ==1.13.4
 
 ########################################################
 # PLEASE READ:


### PR DESCRIPTION
`memray` isn't available for Windows. We should also avoid running geospatial benchmarks on the schedule for now.