### PR TITLE
Fix `tests` CI for TPC-H

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,6 @@ jobs:
           - pytest_args: tests/tpch
             python_version: "3.10"
             os: ubuntu-latest
-            extra-env: ci/environment-tpch-nondask.yml
             name_prefix: tpch
 
     steps:


### PR DESCRIPTION
PySpark 3.X is not compatible with NumPy 2.X