### PR TITLE
Group tests for work-stealing by underlying cluster fixture

### DIFF
--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -22,7 +22,6 @@ small_cluster:
   n_workers: 10
   worker_vm_types: [m6i.large]  # 2CPU, 8GiB
 
-
 # For tests/benchmarks/test_parquet.py
 parquet_cluster:
   n_workers: 15

--- a/cluster_kwargs.yaml
+++ b/cluster_kwargs.yaml
@@ -22,6 +22,7 @@ small_cluster:
   n_workers: 10
   worker_vm_types: [m6i.large]  # 2CPU, 8GiB
 
+
 # For tests/benchmarks/test_parquet.py
 parquet_cluster:
   n_workers: 15

--- a/tests/benchmarks/test_work_stealing.py
+++ b/tests/benchmarks/test_work_stealing.py
@@ -21,6 +21,21 @@ def test_trivial_workload_should_not_cause_work_stealing(small_client):
     small_client.gather(futs)
 
 
+@run_up_to_nthreads("small_cluster", 100, reason="fixed dataset")
+def test_work_stealing_on_inhomogeneous_workload(small_client):
+    np.random.seed(42)
+    delays = np.random.lognormal(1, 1.3, 500)
+
+    @delayed
+    def clog(n):
+        time.sleep(min(n, 60))
+        return n
+
+    results = [clog(i) for i in delays]
+    futs = small_client.compute(results)
+    small_client.gather(futs)
+
+
 @run_up_to_nthreads("small_cluster", 50, reason="fixed dataset")
 @pytest.mark.xfail(
     Version(distributed.__version__) < Version("2022.6.1"),
@@ -68,21 +83,6 @@ def test_work_stealing_on_scaling_up(
                 cluster.scale(20)
 
                 _ = future.result()
-
-
-@run_up_to_nthreads("small_cluster", 100, reason="fixed dataset")
-def test_work_stealing_on_inhomogeneous_workload(small_client):
-    np.random.seed(42)
-    delays = np.random.lognormal(1, 1.3, 500)
-
-    @delayed
-    def clog(n):
-        time.sleep(min(n, 60))
-        return n
-
-    results = [clog(i) for i in delays]
-    futs = small_client.compute(results)
-    small_client.gather(futs)
 
 
 @run_up_to_nthreads("small_cluster", 100, reason="fixed dataset")


### PR DESCRIPTION
Closes #1620

Our clusters get created _once_ per module and get shut down after 2 minutes if no client is connected (and after 20 minutes of idleness). Therefore, we should group tests by the cluster fixture to ensure that they are being utilized back-to-back.

We could potentially increase the `no-client-timeout`, but this still won't work if there's a gap of 20 minutes so I'd prefer either sorting within the module or breaking modules apart bhy cluster.