### PR TITLE
Reduce test matrix for stability tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,24 +30,9 @@ jobs:
         extra-env: [""]
         name_prefix: [tests]
         include:
-          # Run stability tests on the lowest and highest versions of Python only
-          # These are temporarily redundant with the current global python_version
-          # - pytest_args: tests/stability
-          #   python_version: "3.10"
-          #   os: ubuntu-latest
-          #   name_prefix: stability
           - pytest_args: tests/stability
-            python_version: "3.11"
+            python_version: "3.10"
             os: ubuntu-latest
-            name_prefix: stability
-          # Run stability tests on Python Windows and MacOS (latest py39 only)
-          - pytest_args: tests/stability
-            python_version: "3.10"
-            os: windows-latest
-            name_prefix: stability
-          - pytest_args: tests/stability
-            python_version: "3.10"
-            os: macos-latest
             name_prefix: stability
           - pytest_args: tests/workflows/test_snowflake.py
             python_version: "3.10"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,6 @@ jobs:
         name_prefix: [tests]
         include:
           - pytest_args: tests/stability
-            python_version: "3.10"
-            os: ubuntu-latest
             name_prefix: stability
           - pytest_args: tests/workflows/test_snowflake.py
             python_version: "3.10"


### PR DESCRIPTION
When we last discussed recent CI issues, we agreed that we don't care too much about the stability test, in particular a full test matrix. I still see value in having these tests around, in particular `test_install_plugins`, so I am not removing these entirely. This PR simplifies the test matrix to a single run with a default OS and Python version.